### PR TITLE
early return for sampled-out event

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,2 +1,3 @@
 Tim Spencer <tspencer@hungry.com>
 Chris Toshok <toshok@honeycomb.io>
+Jamie Osler <j.osler@gmail.com>

--- a/lib/libhoney/event.rb
+++ b/lib/libhoney/event.rb
@@ -81,6 +81,7 @@ module Libhoney
       # discard if sampling rate says so
       if @libhoney.should_drop(self.sample_rate)
         @libhoney.send_dropped_response(self, "event dropped due to sampling")
+        return
       end
 
       self.send_presampled()


### PR DESCRIPTION
Whilst `@libhoney.should_drop(self.sample_rate)` does return correctly, the code continues on to send the event anyway.

The test raises an exception when `client.send_event` is called - I tried getting this to work using Webmock asserting that the HTTP call was never made, but due to the asynchronous nature of sending that doesn't work very well (test finishes before it's sent).

fixes https://github.com/honeycombio/libhoney-rb/issues/6