### PR TITLE
use faraday instead of http for requests

### DIFF
--- a/lib/libhoney/client.rb
+++ b/lib/libhoney/client.rb
@@ -49,7 +49,7 @@ module Libhoney
     # Instantiates libhoney and prepares it to send events to Honeycomb.
     #
     # @param writekey [String] the write key from your honeycomb team
-    # @param dataset [String] the dataset you want 
+    # @param dataset [String] the dataset you want
     # @param sample_rate [Fixnum] cause libhoney to send 1 out of sampleRate events.  overrides the libhoney instance's value.
     # @param api_host [String] the base url to send events to
     # @param block_on_send [Boolean] if more than pending_work_capacity events are written, block sending further events
@@ -68,7 +68,7 @@ module Libhoney
       raise Exception.new('libhoney:  max_concurrent_batches must be greater than 0') if max_concurrent_batches < 1
       raise Exception.new('libhoney:  sample rate must be greater than 0') if sample_rate < 1
 
-      raise Exception.new("libhoney:  Ruby versions < 2.2 are not supported") if !Gem::Dependency.new("ruby", "~> 2.2").match?("ruby", RUBY_VERSION)      
+      raise Exception.new("libhoney:  Ruby versions < 2.2 are not supported") if !Gem::Dependency.new("ruby", "~> 2.2").match?("ruby", RUBY_VERSION)
       @builder = Builder.new(self, nil)
       @builder.writekey = writekey
       @builder.dataset = dataset

--- a/lib/libhoney/client.rb
+++ b/lib/libhoney/client.rb
@@ -1,7 +1,6 @@
 require 'thread'
 require 'time'
 require 'json'
-require 'http'
 
 # define a few additions that proxy access through Client's builder.  makes Client much tighter.
 class Class

--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -26,7 +26,7 @@ module Libhoney
       @threads = []
       @lock = Mutex.new
     end
-    
+
     def add(event)
       begin
         @send_queue.enq(event, !@block_on_send)
@@ -52,7 +52,6 @@ module Libhoney
 
         conn = Faraday.new(:url => e.api_host) do |faraday|
           faraday.request  :json
-          faraday.response :logger
           faraday.adapter  :net_http_persistent
         end
 

--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -43,17 +43,18 @@ module Libhoney
     end
 
     def send_loop
-      conn = Faraday.new(:url => e.api_host) do |faraday|
-        faraday.request  :json
-        faraday.adapter  :net_http_persistent
-      end
-
       # eat events until we run out
       loop {
         e = @send_queue.pop
         break if e == nil
 
         before = Time.now
+
+        conn = Faraday.new(:url => e.api_host) do |faraday|
+          faraday.request  :json
+          faraday.response :logger
+          faraday.adapter  :net_http_persistent
+        end
 
         resp = conn.post do |req|
           req.url '/1/events/' + e.dataset

--- a/libhoney.gemspec
+++ b/libhoney.gemspec
@@ -29,5 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "yardstick", "~> 0.9"
   spec.add_development_dependency "bump", "~> 0.5"
-  spec.add_dependency "http", "~> 2.0"
+  spec.add_dependency "faraday", "~> 0.12"
+  spec.add_dependency "faraday_middleware", "~> 0.12"
+  spec.add_dependency "net-http-persistent", "~> 3.0"
 end


### PR DESCRIPTION
for some set of large responses, the http gem was raising an error:

> IOError: not opened for reading

i am not completely sure what the conditions for that failure are, but request body size seems to be correlated with this occurring consistently.

switching to faraday fixed the problem.

another thing worth noting is that this error was not being rescued anywhere, which made it quite difficult to spot. that is something that should be addressed regardless of this patch.