### PR TITLE
`writekey` can be supplied via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ honeycomb.send_now({
 honeycomb.close
 ```
 
+It is also possible to supply `writekey` with the `$HONEYCOMB_WRITEKEY` environment variable.
+
 You can find a more complete example demonstrating usage in [`example/fact.rb`](example/fact.rb)
 
 ## Contributions

--- a/lib/libhoney/client.rb
+++ b/lib/libhoney/client.rb
@@ -54,7 +54,7 @@ module Libhoney
     # @param api_host [String] the base url to send events to
     # @param block_on_send [Boolean] if more than pending_work_capacity events are written, block sending further events
     # @param block_on_responses [Boolean] if true, block if there is no thread reading from the response queue
-    def initialize(writekey: '',
+    def initialize(writekey: ENV['HONEYCOMB_WRITEKEY'] || '',
                    dataset: '',
                    sample_rate: 1,
                    api_host: 'https://api.honeycomb.io/',

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -17,6 +17,10 @@ class LibhoneyDefaultTest < Minitest::Test
     assert_equal 10, honey.max_concurrent_batches
     assert_equal 1000, honey.pending_work_capacity
 
+    ENV['HONEYCOMB_WRITEKEY'] = 'env_writekey'
+    honey = Libhoney::Client.new()
+    assert_equal 'env_writekey', honey.writekey
+
     honey = Libhoney::Client.new(:writekey => 'writekey', :dataset => 'dataset', :sample_rate => 4,
                                  :api_host => 'http://something.else', :block_on_send => true,
                                  :block_on_responses => true, :max_batch_size => 100,


### PR DESCRIPTION
A common strategy for managing sensitive data such as API keys is to set
them in the environment prior to starting a program that needs access to
them. Then the program can read from the environment variable at runtime.

This commit enables a similar strategy to work with libhoney out of the
box. If no `writekey` is supplied to `Libhoney::Client` it will check to
see if the `HONEYCOMB_WRITEKEY` environment variable is set. If it is it
will use that, otherwise it will use the empty string like it did
before.

No worries if this is something that you'd envision being handled outside of the gem! It's just something I've seen handled inside in the gem in the past, and I found myself missing it when I reached for it.