### PR TITLE
Try faraday without net-http-persistent

### DIFF
--- a/libhoney.gemspec
+++ b/libhoney.gemspec
@@ -31,5 +31,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bump", "~> 0.5"
   spec.add_dependency "faraday", "~> 0.12"
   spec.add_dependency "faraday_middleware", "~> 0.12"
-  spec.add_dependency "net-http-persistent", "~> 3.0"
 end


### PR DESCRIPTION
Some local testing with memory profiler reveals that the net-http-persistent faraday adapter can leak threads when running our example script.. This switches to the Net::HTTP adapter, which seems to be better-behaved. It's unclear whether it's a bug in how we were using the adapter, or something with some version of the adapter itself, but attempting to dig further into the adapter code was not a fruitful line of inquiry for me. 🤔 