### PR TITLE
Go back to using http gem as http adapter 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,14 @@ gem 'libhoney'
 #gem 'libhoney', git: 'https://github.com/honeycombio/libhoney-rb.git'
 ```
 
-N.B. that libhoney requires Ruby 2.2 or greater.
+This gem has some native dependencies, so if you see an error along the lines of "Failed to build gem native extension", you may need to install the Ruby development headers and a C++ compiler. e.g. on Ubuntu:
+
+```
+sudo apt-get install build-essential ruby-dev
+```
+
+Note that libhoney requires Ruby 2.2 or greater.
+
 
 ## Documentation
 

--- a/lib/libhoney/client.rb
+++ b/lib/libhoney/client.rb
@@ -1,6 +1,7 @@
 require 'thread'
 require 'time'
 require 'json'
+require 'http'
 
 # define a few additions that proxy access through Client's builder.  makes Client much tighter.
 class Class

--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -1,6 +1,4 @@
 require 'libhoney/response'
-require 'faraday'
-require 'faraday_middleware'
 
 module Libhoney
   # @api private
@@ -51,9 +49,20 @@ module Libhoney
         before = Time.now
 
         begin
-          resp = do_send(e)
+          resp = HTTP.headers(
+            'User-Agent' => "libhoney-rb/#{VERSION}",
+            'Content-Type' => 'application/json',
+            'X-Honeycomb-Team' => e.writekey,
+            'X-Honeycomb-SampleRate' => e.sample_rate,
+            'X-Event-Time' => e.timestamp.iso8601
+          ).post(URI.join(e.api_host, '/1/events/', e.dataset), :json => e.data)
 
-          response = Response.new(:status_code => resp.status)
+          after = Time.now
+          response = Response.new(
+            :duration => after - before,
+            :status_code => resp.status,
+            :metadata => e.metadata
+          )
         rescue Exception => error
           # catch a broader swath of exceptions than is usually good practice,
           # because this is effectively the top-level exception handler for the
@@ -88,30 +97,6 @@ module Libhoney
       @responses.enq(nil)
 
       0
-    end
-
-    private
-    def do_send(event)
-      conn = Faraday.new(:url => event.api_host) do |faraday|
-        faraday.request  :json
-        faraday.adapter  :net_http_persistent
-      end
-
-      resp = conn.post do |req|
-        req.url '/1/events/' + event.dataset
-        req.headers = {
-          'User-Agent' => "libhoney-rb/#{VERSION}",
-          'Content-Type' => 'application/json',
-          'X-Honeycomb-Team' => event.writekey,
-          'X-Honeycomb-SampleRate' => event.sample_rate.to_s,
-          'X-Event-Time' => event.timestamp.iso8601
-        }
-        req.body = event.data
-      end
-
-      # TODO handle faraday errors
-
-      resp
     end
   end
 end

--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -57,12 +57,7 @@ module Libhoney
             'X-Event-Time' => e.timestamp.iso8601
           ).post(URI.join(e.api_host, '/1/events/', e.dataset), :json => e.data)
 
-          after = Time.now
-          response = Response.new(
-            :duration => after - before,
-            :status_code => resp.status,
-            :metadata => e.metadata
-          )
+          response = Response.new(:status_code => resp.status)
         rescue Exception => error
           # catch a broader swath of exceptions than is usually good practice,
           # because this is effectively the top-level exception handler for the

--- a/libhoney.gemspec
+++ b/libhoney.gemspec
@@ -29,7 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "yardstick", "~> 0.9"
   spec.add_development_dependency "bump", "~> 0.5"
-  spec.add_dependency "faraday", "~> 0.12"
-  spec.add_dependency "faraday_middleware", "~> 0.12"
-  spec.add_dependency "net-http-persistent", "~> 3.0"
+  spec.add_dependency "http", "~> 2.0"
 end


### PR DESCRIPTION
Alternative to https://github.com/honeycombio/libhoney-rb/pull/16 Our Faraday usage seems potentially correlated to user-reported memory leaks that have been difficult to reproduce & debug. The older adapter did not show the same behavior. We're thinking it may simplify things to go back to using the prior one.