### PR TITLE
Support `Libhoney::Client.new(..., user_agent_addition: 'foo/1.0')`

### DIFF
--- a/lib/libhoney/client.rb
+++ b/lib/libhoney/client.rb
@@ -60,6 +60,7 @@ module Libhoney
                    dataset: '',
                    sample_rate: 1,
                    api_host: 'https://api.honeycomb.io/',
+                   user_agent_addition: nil,
                    transmission: nil,
                    block_on_send: false,
                    block_on_responses: false,
@@ -77,6 +78,8 @@ module Libhoney
       @builder.dataset = dataset
       @builder.sample_rate = sample_rate
       @builder.api_host = api_host
+
+      @user_agent_addition = user_agent_addition
 
       @block_on_send = block_on_send
       @block_on_responses = block_on_responses
@@ -183,7 +186,8 @@ module Libhoney
                                        :pending_work_capacity => @pending_work_capacity,
                                        :responses => @responses,
                                        :block_on_send => @block_on_send,
-                                       :block_on_responses => @block_on_responses)
+                                       :block_on_responses => @block_on_responses,
+                                       :user_agent_addition => @user_agent_addition)
         end
       }
 

--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -9,7 +9,8 @@ module Libhoney
                    pending_work_capacity: 0,
                    responses: 0,
                    block_on_send: 0,
-                   block_on_responses: 0)
+                   block_on_responses: 0,
+                   user_agent_addition: nil)
 
       @responses = responses
       @block_on_send = block_on_send
@@ -18,6 +19,8 @@ module Libhoney
       @send_frequency = send_frequency
       @max_concurrent_batches = max_concurrent_batches
       @pending_work_capacity = pending_work_capacity
+
+      @user_agent = build_user_agent(user_agent_addition).freeze
 
       # use a SizedQueue so the producer will block on adding to the send_queue when @block_on_send is true
       @send_queue = SizedQueue.new(@pending_work_capacity)
@@ -54,7 +57,7 @@ module Libhoney
 
         begin
           resp = HTTP.headers(
-            'User-Agent' => "libhoney-rb/#{VERSION}",
+            'User-Agent' => @user_agent,
             'Content-Type' => 'application/json',
             'X-Honeycomb-Team' => e.writekey,
             'X-Honeycomb-SampleRate' => e.sample_rate,
@@ -96,6 +99,13 @@ module Libhoney
       @responses.enq(nil)
 
       0
+    end
+
+    private
+    def build_user_agent(user_agent_addition)
+      ua = "libhoney-rb/#{VERSION}"
+      ua << " #{user_agent_addition}" if user_agent_addition
+      ua
     end
   end
 end

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -280,3 +280,24 @@ class LibhoneyTest < Minitest::Test
     @honey.close
   end
 end
+
+class LibhoneyUserAgentTest < Minitest::Test
+  def setup
+    stub_request(:post, 'https://api.honeycomb.io/1/events/mydataset').
+      to_return(status: 200, body: 'OK')
+  end
+
+  def test_default_user_agent
+    honey = Libhoney::Client.new(writekey: 'mywritekey', dataset: 'mydataset')
+    honey.send_now('ORLY' => 'YA RLY')
+    honey.close
+    assert_requested :post, /.*/, headers: {'User-Agent': "libhoney-rb/#{::Libhoney::VERSION}"}
+  end
+
+  def test_user_agent_addition
+    honey = Libhoney::Client.new(writekey: 'mywritekey', dataset: 'mydataset', user_agent_addition: 'test/4.2')
+    honey.send_now('ORLY' => 'YA RLY')
+    honey.close
+    assert_requested :post, /.*/, headers: {'User-Agent': %r{libhoney-rb/.* test/4.2}}
+  end
+end


### PR DESCRIPTION
This allows clients to append to the user-agent header, as supported by libhoney-js and libhoney-go. (Primarily wanted for honeycomb-rails.)