### PR TITLE
Preserve timestamp accuracy up to milliseconds

### DIFF
--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -61,7 +61,7 @@ module Libhoney
             'Content-Type' => 'application/json',
             'X-Honeycomb-Team' => e.writekey,
             'X-Honeycomb-SampleRate' => e.sample_rate,
-            'X-Event-Time' => e.timestamp.iso8601
+            'X-Event-Time' => e.timestamp.iso8601(3)
           ).post(URI.join(e.api_host, '/1/events/', URI.escape(e.dataset)), :json => e.data)
 
           response = Response.new(:status_code => resp.status)


### PR DESCRIPTION
Turns out we were truncating event timestamps (whether automatically assigned or user-specified) to the second. This trivial code change gives us millisecond precision instead.

We could get more precision than this if we wanted it - e.g. up to nanoseconds - but doing so would increase network traffic for every event, and we have other SDKs (e.g. JS) which can only provide milliseconds, so this seems good for now.