### PR TITLE
If writekey/dataset not configured, warn and fall back to no-op

### DIFF
--- a/lib/libhoney.rb
+++ b/lib/libhoney.rb
@@ -1,5 +1,6 @@
 require 'libhoney/client'
 require 'libhoney/log_client'
+require 'libhoney/null_client'
 require 'libhoney/test_client'
 require 'libhoney/version'
 require 'libhoney/builder'

--- a/lib/libhoney/null_client.rb
+++ b/lib/libhoney/null_client.rb
@@ -1,0 +1,22 @@
+require 'libhoney/client'
+require 'libhoney/null_transmission'
+
+module Libhoney
+
+  # A no-op client that silently drops events. Does not send events to
+  # Honeycomb, or to anywhere else for that matter.
+  #
+  # This class is intended as a fallback for callers that wanted to instantiate
+  # a regular Client but had insufficient config to do so (e.g. missing
+  # writekey).
+  #
+  # @api private
+  class NullClient < Client
+    def initialize(*args, **kwargs)
+      super(*args,
+            transmission: NullTransmissionClient.new,
+            **kwargs)
+    end
+  end
+
+end

--- a/lib/libhoney/null_transmission.rb
+++ b/lib/libhoney/null_transmission.rb
@@ -1,0 +1,13 @@
+module Libhoney
+  # A no-op version of TransmissionClient that silently drops events (without
+  # sending them to Honeycomb, or anywhere else for that matter).
+  #
+  # @api private
+  class NullTransmissionClient
+    def add(event)
+    end
+
+    def close(drain)
+    end
+  end
+end

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -4,10 +4,20 @@ require 'libhoney'
 require 'webmock/minitest'
 
 class LibhoneyDefaultTest < Minitest::Test
+  def setup
+    # intercept warning emitted for missing writekey
+    @old_stderr = $stderr
+    $stderr = StringIO.new
+  end
+  def teardown
+    $stderr = @old_stderr
+  end
+
   def test_initialize
     honey = Libhoney::Client.new()
-    assert_equal '', honey.writekey
-    assert_equal '', honey.dataset
+    assert_nil honey.writekey
+    assert_nil honey.dataset
+    assert_match(/writekey/, $stderr.string, 'should log a warning due to missing writekey')
     assert_equal 1, honey.sample_rate
     assert_equal 'https://api.honeycomb.io/', honey.api_host
     assert_equal false, honey.block_on_send


### PR DESCRIPTION
This makes `Libhoney::Client` validate the writekey and dataset at initialization time. If they are missing, it emits a warning to standard error and then falls back to a no-op mode where it will accept events and silently drop them.

I believe this is the behaviour you would want in pretty much any circumstance where you omitted the writekey but still initialized a `Libhoney::Client`, and improves on the current behaviour of waiting until event send time and then throwing an exception for every event, which is at best noisy and unhelpful.

Strictly this is backward incompatible, since it was technically possible for someone to leave writekey and dataset unspecified, and instead set them via a builder or on individual events. (This doesn't
remove the latter capability, so it's still possible to send events to multiple teams or datasets using the same `Libhoney::Client` - you just have to pick a default writekey and dataset to initialize the Client.)