### PR TITLE
Use a persistent connection per thread instead of connecting anew for each event

### DIFF
--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -83,12 +83,14 @@ module Libhoney
           # nothing consuming the queue).
           response = Response.new(:error => error)
         ensure
-          response.duration = Time.now - before
-          response.metadata = e.metadata
+          if response
+            response.duration = Time.now - before
+            response.metadata = e.metadata
+          end
         end
 
         begin
-          @responses.enq(response, !@block_on_responses)
+          @responses.enq(response, !@block_on_responses) if response
         rescue ThreadError
           # happens if the queue was full and block_on_send = false.
         end

--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -48,11 +48,10 @@ module Libhoney
     end
 
     def send_loop
-      http_clients = Hash.new do |h, (api_host, writekey)|
-        h[[api_host, writekey]] = HTTP.persistent(api_host).headers(
+      http_clients = Hash.new do |h, api_host|
+        h[api_host] = HTTP.persistent(api_host).headers(
             'User-Agent' => @user_agent,
             'Content-Type' => 'application/json',
-            'X-Honeycomb-Team' => writekey,
         )
       end
 
@@ -64,9 +63,10 @@ module Libhoney
         before = Time.now
 
         begin
-          http = http_clients[[e.api_host, e.writekey]]
+          http = http_clients[e.api_host]
 
           resp = http.post('/1/events/'+URI.escape(e.dataset), json: e.data, headers: {
+            'X-Honeycomb-Team' => e.writekey,
             'X-Honeycomb-SampleRate' => e.sample_rate,
             'X-Event-Time' => e.timestamp.iso8601(3)
           })


### PR DESCRIPTION
Prior to this PR, libhoney-rb is making a brand new HTTPS connection to api.honeycomb.io before sending each event. This is extremely inefficient, incurring both a TCP connection setup and a TLS handshake for each event. Each outbound connection also consumes kernel resources (and continues to do so for around a minute while the connection is in TCP `CLOSE_WAIT`). Finally this may be causing a problem observed by a potential customer who found that libhoney-rb was exhausting their port address translations.

The "http" gem we are using [supports persistent connections](https://github.com/httprb/http/wiki/Persistent-Connections-%28keep-alive%29) using the HTTP/1.1 header `Connection: Keep-Alive`, so let's use them. Each thread in the sending thread pool (default 10 threads) gets its own persistent connection (*) and sends all events it processes on that same connection.

It's hard to obtain a representative benchmark, but my initial results suggest that for a moderately-loaded, multi-threaded Rails app that is not CPU-limited (i.e. CPU is not pegged at 100% during the test), this reduces the CPU overhead of libhoney-rb by a factor of 2-3, as well as reducing the number of open outbound connections from hundreds to 10.

The http gem takes care of managing the persistent connection. We just receive, and reuse, a persistent `Client` object, but under the hood it sets up a `Connection`, detects if it has timed out or been interrupted and reconnects if needed. I've verified this behaviour through local testing and inspection.

(*) Actually, its own set of persistent connections. Because we support specifying the API host per-event, we actually keep a persistent connection _per API host_. This is a nuance that probably matters to zero people, but it also moves us toward the code structure we'll need to support batching (#1).