### PR TITLE
Make example code more representative

### DIFF
--- a/example/factorial.rb
+++ b/example/factorial.rb
@@ -34,13 +34,17 @@ libhoney = Libhoney::Client.new(writekey: writekey,
                                 dataset:  dataset)
 
 Thread.new do
-  loop do
-    response = libhoney.responses.pop
-    break if response.nil?
+  begin
+    loop do
+      response = libhoney.responses.pop
+      break if response.nil?
 
-    puts "Sent: Event with metadata #{response.metadata} in #{response.duration * 1000}ms."
-    puts "Got:  Response code #{response.status_code}"
-    puts
+      puts "Sent: Event with metadata #{response.metadata} in #{response.duration * 1000}ms."
+      puts "Got:  Response code #{response.status_code}"
+      puts
+    end
+  rescue StandardError => e
+    puts "#{e.class} in response reader thread: #{e}"
   end
 end
 

--- a/example/factorial.rb
+++ b/example/factorial.rb
@@ -31,8 +31,7 @@ def run_factorial(low, high, libh_builder)
 end
 
 libhoney = Libhoney::Client.new(writekey: writekey,
-                                dataset:  dataset,
-                                max_concurrent_batches: 1)
+                                dataset:  dataset)
 
 Thread.new do
   loop do

--- a/example/factorial.rb
+++ b/example/factorial.rb
@@ -41,6 +41,7 @@ Thread.new do
 
       puts "Sent: Event with metadata #{response.metadata} in #{response.duration * 1000}ms."
       puts "Got:  Response code #{response.status_code}"
+      puts "      #{response.error.class}: #{response.error}" if response.error
       puts
     end
   rescue StandardError => e

--- a/example/factorial.rb
+++ b/example/factorial.rb
@@ -30,9 +30,13 @@ def run_factorial(low, high, libh_builder)
   end
 end
 
-def read_responses(response_queue)
+libhoney = Libhoney::Client.new(writekey: writekey,
+                                dataset:  dataset,
+                                max_concurrent_batches: 1)
+
+Thread.new do
   loop do
-    response = response_queue.pop
+    response = libhoney.responses.pop
     break if response.nil?
 
     puts "Sent: Event with metadata #{response.metadata} in #{response.duration * 1000}ms."
@@ -41,38 +45,24 @@ def read_responses(response_queue)
   end
 end
 
-libhoney = Libhoney::Client.new(writekey: writekey,
-                                dataset:  dataset,
-                                max_concurrent_batches: 1)
+# attach fields to top-level instance
+libhoney.add_field('version', '3.4.5')
 
-responses = libhoney.responses
+a_proc = proc { Thread.list.select { |thread| thread.status == 'run' }.count }
+libhoney.add_dynamic_field('num_threads', a_proc)
 
-Thread.new do
-  begin
-    # attach fields to top-level instance
-    libhoney.add_field('version', '3.4.5')
-
-    a_proc = proc { Thread.list.select { |thread| thread.status == 'run' }.count }
-    libhoney.add_dynamic_field('num_threads', a_proc)
-
-    event = libhoney.event
-    event.metadata = { fn: 'work_thread' }
-    event.add_field('start_time', Time.now.iso8601(3))
-    event.with_timer 'run_fact_low_dur_ms' do
-      run_factorial(1, 20, libhoney.builder(range: 'low'))
-    end
-    event.with_timer 'run_fact_high_dur_ms' do
-      run_factorial(31, 40, libhoney.builder(range: 'high'))
-    end
-    event.add_field('end_time', Time.now.iso8601(3))
-    # sends an event with "version", "num_threads", "start_time", "end_time",
-    # "run_fact_low_dur_ms", "run_fact_high_dur_ms"
-    event.send
-
-    libhoney.close
-  rescue StandardError => e
-    puts e
-  end
+event = libhoney.event
+event.metadata = { fn: 'work_thread' }
+event.add_field('start_time', Time.now.iso8601(3))
+event.with_timer 'run_fact_low_dur_ms' do
+  run_factorial(1, 20, libhoney.builder(range: 'low'))
 end
+event.with_timer 'run_fact_high_dur_ms' do
+  run_factorial(31, 40, libhoney.builder(range: 'high'))
+end
+event.add_field('end_time', Time.now.iso8601(3))
+# sends an event with "version", "num_threads", "start_time", "end_time",
+# "run_fact_low_dur_ms", "run_fact_high_dur_ms"
+event.send
 
-read_responses(responses)
+libhoney.close


### PR DESCRIPTION
Our in-repo "factorial" example script is the only documented example of how to consume the libhoney-rb response queue. However, it documents doing so in a fairly odd way: it starts a background thread to run the actual program (computing factorials), then consumes the response queue in a blocking manner in the _main_ thread.

This is configuration is unlikely to resemble any actual app, where the main thread is likely to be doing the actual work, and is very unlike most web apps where the main thread is handed off to the app server. If someone in the latter configuration tries to emulate this setup, they may even end up deadlocking, if they try to consume the response queue (which will block) before actually running their app to generate any events.

To be a more useful example, this flips the setup, consuming the response queue in a background thread and running the actual factorial script in the main thread. This (consuming responses in the background) is the setup I would expect someone to use in a real app, whether for debugging libhoney in dev or actually inspecting libhoney behaviour in production.

(whitespace-ignoring diff recommended)