### PR TITLE
Time out HTTP requests

### DIFF
--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -46,7 +46,8 @@ module Libhoney
     def send_loop
       http_clients = Hash.new do |h, api_host|
         h[api_host] = HTTP.timeout(connect: @send_timeout, write: @send_timeout, read: @send_timeout)
-                          .persistent(api_host).headers(
+                          .persistent(api_host)
+                          .headers(
                             'User-Agent'   => @user_agent,
                             'Content-Type' => 'application/json'
                           )

--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -7,6 +7,7 @@ module Libhoney
                    send_frequency: 100,
                    max_concurrent_batches: 10,
                    pending_work_capacity: 1000,
+                   send_timeout: 10,
                    responses: nil,
                    block_on_send: false,
                    block_on_responses: false,
@@ -19,6 +20,7 @@ module Libhoney
       @send_frequency         = send_frequency
       @max_concurrent_batches = max_concurrent_batches
       @pending_work_capacity  = pending_work_capacity
+      @send_timeout           = send_timeout
       @user_agent             = build_user_agent(user_agent_addition).freeze
 
       # use a SizedQueue so the producer will block on adding to the send_queue when @block_on_send is true
@@ -43,10 +45,11 @@ module Libhoney
 
     def send_loop
       http_clients = Hash.new do |h, api_host|
-        h[api_host] = HTTP.persistent(api_host).headers(
-          'User-Agent'   => @user_agent,
-          'Content-Type' => 'application/json'
-        )
+        h[api_host] = HTTP.timeout(connect: @send_timeout, write: @send_timeout, read: @send_timeout)
+                          .persistent(api_host).headers(
+                            'User-Agent'   => @user_agent,
+                            'Content-Type' => 'application/json'
+                          )
       end
 
       # eat events until we run out


### PR DESCRIPTION
Consistent with https://github.com/honeycombio/libhoney-py/pull/45 and https://github.com/honeycombio/libhoney-go/pull/34, this adds a 10 second timeout to each HTTP POST.

The `http.rb` library we're using supports granular timeouts for `connect`, `write` and `read`. For now, this just sets them all to 10 seconds. That means in principle a request could still last for 30 seconds without timing out (10s to connect, 10s to write the headers and event body, 10s to read the response headers). In practice, slowness in each phase is likely to have a different cause (e.g. connect slowness is probably the network, write/read probably shepherd hanging), so in most cases I'd expect this to time out after 10 seconds as desired.

This doesn't make the timeouts user-configurable, but it would be easy to add them to `Client` and plumb them through if someone asks for it.

Tested on my laptop by hardcoding `api_host` to `localhost:9379`, running `nc -l 9379` and hitting Ctrl-Z to suspend it. (That leaves the socket open and its buffer accepting writes, but nothing writing responses back, which hits the read timeout.)