### PR TITLE
Update API docs/examples

### DIFF
--- a/lib/libhoney/client.rb
+++ b/lib/libhoney/client.rb
@@ -29,9 +29,7 @@ end
 module Libhoney
   ##
   # This is a library to allow you to send events to Honeycomb from within your
-  # ruby application.
-  #
-  # note that by default, the max queue size is 1000.  if the queue gets bigger than that, we start dropping events.
+  # Ruby application.
   #
   # @example Send a simple event
   #   require 'libhoney'
@@ -70,6 +68,8 @@ module Libhoney
     # @param transmission [Object] transport used to actually send events. If nil (the default), will be lazily initialized with a {TransmissionClient} on first event send.
     # @param block_on_send [Boolean] if more than pending_work_capacity events are written, block sending further events
     # @param block_on_responses [Boolean] if true, block if there is no thread reading from the response queue
+    # @param pending_work_capacity [Fixnum] defaults to 1000. If the queue of
+    #   pending events exceeds 1000, this client will start dropping events.
     def initialize(writekey: nil,
                    dataset: nil,
                    sample_rate: 1,

--- a/lib/libhoney/client.rb
+++ b/lib/libhoney/client.rb
@@ -31,33 +31,42 @@ module Libhoney
   # This is a library to allow you to send events to Honeycomb from within your
   # ruby application.
   #
-  # Example:
+  # note that by default, the max queue size is 1000.  if the queue gets bigger than that, we start dropping events.
+  #
+  # @example Send a simple event
   #   require 'libhoney'
-  #   honey = Libhoney.new(writekey, dataset, url, sample_rate, num_workers)
-  #   event = honey.event
-  #   event.add({'pglatency' => 100})
-  #   honey.send(event)
-  #   <repeat creating and sending events until your program is finished>
+  #   honey = Libhoney.new(writekey, dataset, sample_rate)
+  #
+  #   evt = honey.event
+  #   evt.add(pglatency: 100)
+  #   honey.send(evt)
+  #
+  #   # repeat creating and sending events until your program is finished
+  #
   #   honey.close
   #
-  # Arguments:
-  # * *writekey* is the key to use the Honeycomb service (required)
-  # * *dataset* is the dataset to write into (required)
-  # * *sample_rate* is how many samples you want to keep.  IE:  1 means you want 1 out of 1 samples kept, or all of them.  10 means you want 1 out of 10 samples kept.  And so on.
-  # * *url* is the url to connect to Honeycomb
-  # * *num_workers* is the number of threads working on the queue of events you are generating
+  # @example Override the default timestamp on an event
+  #   one_hour_ago = Time.now - 3600
   #
-  # Note that by default, the max queue size is 1000.  If the queue gets bigger than that, we start dropping events.
+  #   evt = libhoney.event
+  #   evt.add_fields(useful_fields)
+  #   evt.timestamp = one_hour_ago
+  #   evt.send
   #
   class Client
     API_HOST = 'https://api.honeycomb.io/'.freeze
 
     # Instantiates libhoney and prepares it to send events to Honeycomb.
     #
-    # @param writekey [String] the write key from your honeycomb team (required)
-    # @param dataset [String] the dataset you want (required)
-    # @param sample_rate [Fixnum] cause libhoney to send 1 out of sampleRate events.  overrides the libhoney instance's value.
-    # @param api_host [String] the base url to send events to
+    # @param writekey [String] the Honeycomb API key with which to authenticate
+    #   this request (required)
+    # @param dataset [String] the Honeycomb dataset into which to send events (required)
+    # @param sample_rate [Fixnum] cause +libhoney+ to send 1 out of +sample_rate+ events.
+    #   overrides the libhoney instance's value.  (e.g. setting this to +10+ will result in
+    #   a 1-in-10 chance of it being successfully emitted to Honeycomb, and the
+    #   Honeycomb query engine will interpret it as representative of 10 events)
+    # @param api_host [String] defaults to +API_HOST+, override to change the
+    #   destination for these Honeycomb events.
     # @param transmission [Object] transport used to actually send events. If nil (the default), will be lazily initialized with a {TransmissionClient} on first event send.
     # @param block_on_send [Boolean] if more than pending_work_capacity events are written, block sending further events
     # @param block_on_responses [Boolean] if true, block if there is no thread reading from the response queue

--- a/lib/libhoney/event.rb
+++ b/lib/libhoney/event.rb
@@ -1,11 +1,44 @@
 module Libhoney
-  ##
   # This is the event object that you can fill up with data.
+  #
+  # @example Override the default timestamp on an event
+  #   evt = libhoney.event
+  #   evt.add_fields(useful_fields)
+  #   evt.timestamp = Time.now
+  #   evt.send
+  #
   class Event
-    attr_accessor :writekey, :dataset, :sample_rate, :api_host
-    attr_accessor :timestamp, :metadata
+    # @return [String] the Honeycomb API key with which to authenticate this
+    #   request
+    attr_accessor :writekey
 
-    # @return [Hash<String=>any>] the fields in this event
+    # @return [String] the Honeycomb dataset this event is destined for
+    #   (defaults to the +Builder+'s +dataset+, which in turn defaults to the
+    #   +Client+'s +dataset+)
+    attr_accessor :dataset
+
+    # @return [Fixnum] Set this attribute to indicate that it represents
+    #   +sample_rate+ number of events (e.g. setting this to +10+ will result in
+    #   a 1-in-10 chance of it being successfully emitted to Honeycomb, and the
+    #   Honeycomb query engine will interpret it as representative of 10 events)
+    attr_accessor :sample_rate
+
+    # @return [String] Set this attribute in order to override the destination
+    #   of these Honeycomb events (defaults to +Client::API_HOST+).
+    attr_accessor :api_host
+
+    # @return [Object] Set this attribute to any +Object+ you might need to
+    #   identify this Event as it is returned to the responses queue (e.g. tag
+    #   an Event with an internal ID in order to retry something specific on
+    #   failure).
+    attr_accessor :metadata
+
+    # @return [Time] Set this attribute in order to override the timestamp
+    #   associated with the event (defaults to the +Time.now+ at +Event+
+    #   creation)
+    attr_accessor :timestamp
+
+    # @return [Hash<String=>any>] the fields added to this event
     attr_reader :data
 
     # @api private
@@ -71,7 +104,7 @@ module Libhoney
       self
     end
 
-    # sends this event to honeycomb
+    # sends this event to Honeycomb
     #
     # @return [self] this event.
     def send
@@ -84,7 +117,7 @@ module Libhoney
       send_presampled
     end
 
-    # sends a presampled event to honeycomb
+    # sends a presampled event to Honeycomb
     #
     # @return [self] this event.
     def send_presampled


### PR DESCRIPTION
Address some common points of confusion around manipulating timestamps. (Update to internal docs coming shortly)

This is another relatively low-pri PR around improving the API docs in `libhoney-rb`. eefb6fd has the interesting stuff that I was trying to add / clean up / make clearer and is likely worth looking at separately from the "fix up everything else rubocop complained about" set of changes.