### PR TITLE
Clean data before sending

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,7 +19,7 @@ Metrics/ClassLength:
     - test/*
 
 Metrics/MethodLength:
-  Max: 35
+  Max: 40
   Exclude:
     - lib/libhoney/transmission.rb
     - test/*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,7 +19,7 @@ Metrics/ClassLength:
     - test/*
 
 Metrics/MethodLength:
-  Max: 25
+  Max: 35
   Exclude:
     - lib/libhoney/transmission.rb
     - test/*

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,17 +14,17 @@ Lint/HandleExceptions:
 
 # Offense count: 7
 Metrics/AbcSize:
-  Max: 35
+  Max: 40
 
 # Offense count: 1
 # Configuration parameters: CountComments, ExcludedMethods.
 # ExcludedMethods: refine
 Metrics/BlockLength:
-  Max: 27
+  Max: 30
 
 # Offense count: 2
 Metrics/CyclomaticComplexity:
-  Max: 8
+  Max: 12
 
 # Offense count: 2
 # Configuration parameters: CountKeywordArgs.
@@ -33,4 +33,4 @@ Metrics/ParameterLists:
 
 # Offense count: 1
 Metrics/PerceivedComplexity:
-  Max: 8
+  Max: 10

--- a/lib/libhoney/cleaner.rb
+++ b/lib/libhoney/cleaner.rb
@@ -4,11 +4,19 @@ module Libhoney
     RECURSION = '[RECURSION]'.freeze
     RAISED = '[RAISED]'.freeze
 
+    # Cleans an object for converting to JSON. Checks for recursion,
+    # exceptions generated, and non UTF8 encoded strings.
+    # @param data the data to clean
+    # @param seen [Hash] used to check for recursion
+    # @return the cleaned object
     def clean_data(data, seen = {})
       return nil if data.nil?
 
+      # check for recursion here, by tracking all of the potentially nested
+      # objects that we have seen before.
       protection =  case data
                     when Hash, Array, Set
+                      # bail here if we have already seen this object
                       return seen[data] if seen[data]
 
                       seen[data] = RECURSION
@@ -42,6 +50,9 @@ module Libhoney
       value
     end
 
+    # Converts a string to UTF8 encoding if required using the ENCODING_OPTIONS
+    # @param str [String] the string to convert
+    # @return [String] the UTF8 encoded string
     def clean_string(str)
       return str if str.encoding == Encoding::UTF_8 && str.valid_encoding?
 

--- a/lib/libhoney/cleaner.rb
+++ b/lib/libhoney/cleaner.rb
@@ -1,9 +1,7 @@
 module Libhoney
   module Cleaner
     ENCODING_OPTIONS = { invalid: :replace, undef: :replace }.freeze
-    FILTERED = '[FILTERED]'.freeze
     RECURSION = '[RECURSION]'.freeze
-    OBJECT = '[OBJECT]'.freeze
     RAISED = '[RAISED]'.freeze
 
     def clean_data(data, seen = {})
@@ -33,15 +31,11 @@ module Libhoney
                 clean_string(data)
               else
                 str = begin
-                        obj.to_s
+                        data.to_s
                       rescue StandardError
                         RAISED
                       end
-                if str =~ /#<.*>/
-                  OBJECT
-                else
-                  clean_string(str)
-                end
+                clean_string(str)
               end
 
       seen[data] = value if protection

--- a/lib/libhoney/cleaner.rb
+++ b/lib/libhoney/cleaner.rb
@@ -1,0 +1,57 @@
+module Libhoney
+  module Cleaner
+    ENCODING_OPTIONS = { invalid: :replace, undef: :replace }.freeze
+    FILTERED = '[FILTERED]'.freeze
+    RECURSION = '[RECURSION]'.freeze
+    OBJECT = '[OBJECT]'.freeze
+    RAISED = '[RAISED]'.freeze
+
+    def clean_data(data, seen = {})
+      return nil if data.nil?
+
+      protection =  case data
+                    when Hash, Array, Set
+                      return seen[data] if seen[data]
+
+                      seen[data] = RECURSION
+                    end
+
+      value = case data
+              when Hash
+                clean_hash = {}
+                data.each do |key, val|
+                  clean_hash[key] = clean_data(val, seen)
+                end
+                clean_hash
+              when Array, Set
+                data.map do |element|
+                  clean_data(element, seen)
+                end
+              when Numeric, TrueClass, FalseClass
+                data
+              when String
+                clean_string(data)
+              else
+                str = begin
+                        obj.to_s
+                      rescue StandardError
+                        RAISED
+                      end
+                if str =~ /#<.*>/
+                  OBJECT
+                else
+                  clean_string(str)
+                end
+              end
+
+      seen[data] = value if protection
+      value
+    end
+
+    def clean_string(str)
+      return str if str.encoding == Encoding::UTF_8 && str.valid_encoding?
+
+      str.encode(Encoding::UTF_8, ENCODING_OPTIONS)
+    end
+  end
+end

--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -1,10 +1,13 @@
 require 'json'
 require 'timeout'
 require 'libhoney/response'
+require 'libhoney/cleaner'
 
 module Libhoney
   # @api private
   class TransmissionClient
+    include Cleaner
+
     def initialize(max_batch_size: 50,
                    send_frequency: 100,
                    max_concurrent_batches: 10,
@@ -63,6 +66,7 @@ module Libhoney
         begin
           http = http_clients[api_host]
           body = serialize_batch(batch)
+
           next if body.nil?
 
           headers = {
@@ -179,11 +183,14 @@ module Libhoney
       payload = []
       batch.map! do |event|
         begin
+          data = clean_data(event.data)
+
           e = {
             time: event.timestamp.iso8601(3),
             samplerate: event.sample_rate,
-            data: event.data
+            data: data
           }
+
           payload << JSON.generate(e)
 
           event

--- a/test/cleaner_test.rb
+++ b/test/cleaner_test.rb
@@ -1,0 +1,39 @@
+require 'minitest/autorun'
+require 'minitest/mock'
+require 'libhoney'
+require 'libhoney/cleaner'
+
+class CleanerTest < Minitest::Test
+  include Libhoney::Cleaner
+
+  def test_recursive_data
+    data = {}
+    interesting_data = {}
+
+    data[:test] = interesting_data
+    interesting_data[:test] = data
+
+    clean_data = clean_data(data, {})
+
+    assert_equal({ test: '[RECURSION]' }, clean_data)
+  end
+
+  def test_invalid_strings
+    data = { not_a_good_string: "\x89" }
+
+    clean_data = clean_data(data, {})
+
+    assert_equal({ not_a_good_string: '�' }, clean_data)
+  end
+
+  def test_objects
+    data = { object_information: CustomObject.new }
+
+    clean_data = clean_data(data, {})
+
+    assert_includes(clean_data.keys, :object_information)
+  end
+
+  class CustomObject
+  end
+end

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -210,6 +210,7 @@ class LibhoneyTest < Minitest::Test
     event = @honey.event
     event.dataset = 'mydataset-send'
     event.add('argle' => 'bargle')
+    event.add('invalid_characters' => "\x89")
     event.send
 
     assert_instance_of Libhoney::Event, event


### PR DESCRIPTION
In the case of an error serializing the events data the event gets dropped. This adds some ability to clean the data object so that it can still be sent. This should fix #36 and https://github.com/honeycombio/beeline-ruby/issues/41

Benchmarking, using the following code and pointing at a local endpoint that just returns 200.

```ruby
require "benchmark"
require "libhoney"
libhoney = Libhoney::Client.new(writekey: writekey, dataset: dataset, api_host: "localhost:4567")
Benchmark.bm do |b|
  b.report do
    1000.times do
      event = libhoney.event
      event.add({ wow: "wee", "wee" => "wow" })
      event.add_field("look", "here")
      event.send
    end
    libhoney.close(true)
  end
end
```

Current version:

|user|system|total|real|
|---|---|---|---|
|0.058666|0.025970|0.084636|(  0.077860)|
|0.065547|0.031916|0.097463|(  0.089169)|
|0.060360|0.027771|0.088131|(  0.081538)|
|0.060432|0.027913|0.088345|(  0.080946)|
|0.064040|0.032437|0.096477|(  0.087880)|
|0.056276|0.025963|0.082239|(  0.075059)|
|0.061170|0.026536|0.087706|(  0.081571)|
|0.059400|0.026908|0.086308|(  0.078791)|
|0.057387|0.026713|0.084100|(  0.076532)|
|0.059217|0.026823|0.086040|(  0.078644)|

This version:

|user|system|total|real|
|---|---|---|---|
|0.062588|0.026430|0.089018|(  0.081445)|
|0.063945|0.027953|0.091898|(  0.083822)|
|0.063435|0.026462|0.089897|(  0.082740)|
|0.073152|0.028985|0.102137|(  0.098140)|
|0.064425|0.025991|0.090416|(  0.082965)|
|0.062538|0.025697|0.088235|(  0.081180)|
|0.065444|0.025701|0.091145|(  0.084251)|
|0.060570|0.026059|0.086629|(  0.079202)|
|0.061412|0.025793|0.087205|(  0.079637)|
|0.062734|0.026838|0.089572|(  0.082099)|