### PR TITLE
Remove references to deprecated gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@ Requires Ruby 2.2 or greater.
 - [Usage and Examples](https://docs.honeycomb.io/sdk/ruby/)
 - [API Reference](https://www.rubydoc.info/gems/libhoney)
 
-For tracing support and automatic instrumentation of Sinatra, Rack, ActiveRecord, and other frameworks, check out our [Beeline for Ruby](https://github.com/honeycombio/beeline-ruby).
-
-For automatic instrumentation of Ruby on Rails, check out our [Rails integration](https://github.com/honeycombio/honeycomb-rails).
+For tracing support and automatic instrumentation of Rails, Sinatra, Rack, ActiveRecord, and other frameworks, check out our [Beeline for Ruby](https://github.com/honeycombio/beeline-ruby).
 
 ## Contributions
 


### PR DESCRIPTION
Also add rails to the list of supported frameworks for the beeline