### PR TITLE
Allow newer http.rb and bundler versions

### DIFF
--- a/libhoney.gemspec
+++ b/libhoney.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.2.0'
 
   spec.add_development_dependency 'bump', '~> 0.5'
-  spec.add_development_dependency 'bundler', '~> 1.7'
+  spec.add_development_dependency 'bundler', '>= 1.7'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'rubocop'
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard'
   spec.add_development_dependency 'yardstick', '~> 0.9'
   spec.add_dependency 'addressable', '~> 2.0'
-  spec.add_dependency 'http', '>= 2.0', '< 4.0'
+  spec.add_dependency 'http', '>= 2.0', '< 5.0'
 end


### PR DESCRIPTION
In our app, we're using Bundler 2.0 and http-4.0.3. I wanted to try out the honeycomb-beeline gem, but it requires `http < 4.0` for some reason. I don't think anything changed in 4.0 that would have affected this gem's usage of it: https://github.com/httprb/http/blob/master/CHANGES.md#400-2018-10-15

Using this branch "works" in my small local testing, but I'm not a large user of honeycomb, so I have not tested it exhaustively.