### PR TITLE
Ensure the type of status_code is always the same

### DIFF
--- a/lib/libhoney/response.rb
+++ b/lib/libhoney/response.rb
@@ -1,9 +1,11 @@
+require 'http'
+
 module Libhoney
   class Response
     attr_accessor :duration, :status_code, :metadata, :error
 
     def initialize(duration: 0,
-                   status_code: 0,
+                   status_code: HTTP::Response::Status.new(0),
                    metadata: nil,
                    error: nil)
       @duration    = duration

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -290,6 +290,7 @@ class LibhoneyTest < Minitest::Test
     20.times do
       response = @honey.responses.pop
       assert_kind_of(Exception, response.error)
+      assert_kind_of(HTTP::Response::Status, response.status_code)
     end
 
     @honey.send_now('argle' => 'bargle')


### PR DESCRIPTION
Although you can check the `error` property on the response it is nicer
to always have the same type being returned for the status_code