### PR TITLE
Send events to the batch endpoint instead of the single event endpoint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,11 @@ Lint/RescueException:
   Exclude:
     - 'lib/libhoney/transmission.rb'
 
+Metrics/BlockLength:
+  Max: 35
+
 Metrics/ClassLength:
+  Max: 150
   Exclude:
     - test/*
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,7 +14,7 @@ Metrics/BlockLength:
   Max: 35
 
 Metrics/ClassLength:
-  Max: 150
+  Max: 200
   Exclude:
     - test/*
 

--- a/lib/libhoney/response.rb
+++ b/lib/libhoney/response.rb
@@ -5,11 +5,11 @@ module Libhoney
     attr_accessor :duration, :status_code, :metadata, :error
 
     def initialize(duration: 0,
-                   status_code: HTTP::Response::Status.new(0),
+                   status_code: 0,
                    metadata: nil,
                    error: nil)
       @duration    = duration
-      @status_code = status_code
+      @status_code = HTTP::Response::Status.new(status_code)
       @metadata    = metadata
       @error       = error
     end

--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -26,10 +26,10 @@ module Libhoney
       @send_timeout           = send_timeout
       @user_agent             = build_user_agent(user_agent_addition).freeze
 
-      # use a SizedQueue so the producer will block on adding to the send_queue when @block_on_send is true
       @send_queue   = Queue.new
       @threads      = []
       @lock         = Mutex.new
+      # use a SizedQueue so the producer will block on adding to the batch_queue when @block_on_send is true
       @batch_queue  = SizedQueue.new(@pending_work_capacity)
       @batch_thread = nil
     end

--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -74,12 +74,12 @@ module Libhoney
             headers: headers
           )
           process_response(response, before, batch)
-        rescue Exception => error
+        rescue Exception => e
           # catch a broader swath of exceptions than is usually good practice,
           # because this is effectively the top-level exception handler for the
           # sender threads, and we don't want those threads to die (leaving
           # nothing consuming the queue).
-          response = Response.new(error: error)
+          response = Response.new(error: e)
           begin
             @responses.enq(response, !@block_on_responses)
           rescue ThreadError
@@ -169,8 +169,8 @@ module Libhoney
           payload << JSON.generate(e)
 
           event
-        rescue StandardError => err
-          Response.new(error: err).tap do |response|
+        rescue StandardError => e
+          Response.new(error: e).tap do |response|
             response.metadata = event.metadata
             begin
               @responses.enq(response, !@block_on_responses)

--- a/libhoney.gemspec
+++ b/libhoney.gemspec
@@ -27,6 +27,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'sinatra'
+  spec.add_development_dependency 'sinatra-contrib'
   spec.add_development_dependency 'webmock', '~> 3.4'
   spec.add_development_dependency 'yard'
   spec.add_development_dependency 'yardstick', '~> 0.9'

--- a/libhoney.gemspec
+++ b/libhoney.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 12.3'
-  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'rubocop', '< 0.69'
   spec.add_development_dependency 'sinatra'
   spec.add_development_dependency 'sinatra-contrib'
   spec.add_development_dependency 'webmock', '~> 3.4'

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -186,7 +186,8 @@ class LibhoneyTest < Minitest::Test
     times_to_test = 900
     events = 0
 
-    stub_request(:post, 'https://api.honeycomb.io/1/batch/mydataset-send').to_rack(HoneycombServer)
+    stub_request(:post, 'https://api.honeycomb.io/1/batch/mydataset-send')
+      .to_rack(HoneycombServer)
 
     event = @honey.event
     event.dataset = 'mydataset-send'

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -305,7 +305,9 @@ class LibhoneyTest < Minitest::Test
     stub_request(:post, 'https://api.honeycomb.io/1/batch/mydataset')
       .to_raise('the network is dark and full of errors')
 
-    20.times do
+    error_count = 20
+
+    error_count.times do
       event = @honey.event
       event.add_field 'hi', 'bye'
       event.send
@@ -314,9 +316,12 @@ class LibhoneyTest < Minitest::Test
     @honey.close
 
     while (response = @honey.responses.pop)
+      error_count -= 1
       assert_kind_of(Exception, response.error)
       assert_kind_of(HTTP::Response::Status, response.status_code)
     end
+
+    assert_equal(0, error_count)
 
     stub_request(:post, 'https://api.honeycomb.io/1/batch/mydataset')
       .to_rack(HoneycombServer)


### PR DESCRIPTION
Changes the endpoint that we send events to the [batch endpoint](https://docs.honeycomb.io/api/events/#batched-events).

The previous flow of events was like this:

- event
- queue
- threads * `max_concurrent_batches`
  - send event to events endpoint and push response to responses queue

we now have the following flow:

- event
- queue
- thread
  - read event off queue
  - add to hash keyed on dataset, apikey, and apihost
  - every `send_frequency`
    - take the hash and split each set of events into groups of `max_batch_size`
    - push each batch onto queue
- threads * `max_concurrent_batches`
  - serialise each event to JSON, send errors to responses queue
  - send each serialised batch to batch endpoint
  - send errors to the responses queue
  - read response and push a response onto the responses queue for each event status returned in the response

# Benchmarking

Using the following code, to send 1000 events using both the current version of libhoney and this new method

```
require "benchmark"
require "libhoney"

libhoney = Libhoney::Client.new(writekey: "...", dataset: "libhoney-benchmark")

b = Benchmark.measure do
  1000.times do
    event = libhoney.event
    event.add_field("look", "here")
    event.send
  end

  libhoney.close(true)
end

puts b
```

Current version:

|user|system|total|real|
|---|---|---|---|
|2.020500|0.119861|2.140361|(  7.310318)|
|1.965627|0.117135|2.082762|(  7.354831)|
|2.012084|0.123885|2.135969|(  7.436962)|

New version:

|user|system|total|real|
|---|---|---|---|
|0.107759|0.041983|0.149742|(  0.493777)|
|0.091437|0.039685|0.131122|(  0.530462)|
|0.111085|0.037703|0.148788|(  0.482274)|