### PR TITLE
Handle full response queue on close

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,7 @@ test_steps: &test_steps
       command: bundle exec rake rubocop
   - run:
       name: run tests
-      environment:
-        TESTOPS: --verbose
-      command: bundle exec rake test
+      command: TESTOPS="--verbose" bundle exec rake test
 
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ test_steps: &test_steps
       command: bundle exec rake rubocop
   - run:
       name: run tests
-      command: TESTOPS="--verbose" bundle exec rake test
+      command: bundle exec rake test
 
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,8 @@ test_steps: &test_steps
       command: bundle exec rake rubocop
   - run:
       name: run tests
+      environment:
+        TESTOPS: --verbose
       command: bundle exec rake test
 
 
@@ -40,7 +42,7 @@ jobs:
     docker:
       - image: circleci/ruby:2.6
     steps: *test_steps
-  publish: 
+  publish:
     docker:
       # Just randomly pick one recent ruby version
       - image: circleci/ruby:2.6

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,3 +29,7 @@ Metrics/LineLength:
   Exclude:
     - lib/libhoney/client.rb
     - lib/libhoney/builder.rb
+
+Metrics/AbcSize:
+  Exclude:
+    - test/*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,7 @@ Metrics/MethodLength:
   Max: 25
   Exclude:
     - lib/libhoney/transmission.rb
+    - test/*
 
 Metrics/LineLength:
   Max: 115

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,6 @@ Rake::TestTask.new(:test) do |t|
   t.libs << 'test'
   t.libs << 'lib'
   t.test_files = FileList['test/**/*_test.rb']
-  t.verbose = true
 end
 
 YARD::Rake::YardocTask.new(:doc)

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,7 @@ Rake::TestTask.new(:test) do |t|
   t.libs << 'test'
   t.libs << 'lib'
   t.test_files = FileList['test/**/*_test.rb']
+  t.verbose = true
 end
 
 YARD::Rake::YardocTask.new(:doc)

--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -151,11 +151,10 @@ module Libhoney
     private
 
     ##
-    # Enqueues a response only if there is something waiting on the queue.
+    # Enqueues a response to the responses queue suppressing ThreadError when
+    # there is no space left on the queue and we are not blocking on response
     #
     def enqueue_response(response)
-      return unless @responses.num_waiting > 0
-
       begin
         @responses.enq(response, !@block_on_responses)
       rescue ThreadError

--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -155,10 +155,8 @@ module Libhoney
     # there is no space left on the queue and we are not blocking on response
     #
     def enqueue_response(response)
-      begin
-        @responses.enq(response, !@block_on_responses)
-      rescue ThreadError
-      end
+      @responses.enq(response, !@block_on_responses)
+    rescue ThreadError
     end
 
     def process_response(http_response, before, batch)

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -203,6 +203,10 @@ class LibhoneyTest < Minitest::Test
       events += 1 while @honey.responses.pop
     end
 
+    # ensure that the thread above is waiting for
+    # an event to be pushed onto the queue
+    sleep 0.1 while t.status!='sleep'
+
     (1..times_to_test).each do |i|
       event = @honey.event
       event.dataset = 'mydataset-send'
@@ -435,6 +439,10 @@ class LibhoneyResponseBlaster < Minitest::Test
     t = Thread.new do
       events += 1 while @honey.responses.pop
     end
+
+    # ensure that the thread above is waiting for
+    # an event to be pushed onto the queue
+    sleep 0.1 while t.status!='sleep'
 
     (1..@times_to_test).each do |i|
       event = @honey.event

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -445,6 +445,8 @@ class LibhoneyResponseBlaster < Minitest::Test
     end
     @honey.close
     t.join
+
+    assert_equal @times_to_test, events
   end
 
   ##

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -205,7 +205,7 @@ class LibhoneyTest < Minitest::Test
 
     # ensure that the thread above is waiting for
     # an event to be pushed onto the queue
-    sleep 0.1 while t.status!='sleep'
+    sleep 0.1 while t.status != 'sleep'
 
     (1..times_to_test).each do |i|
       event = @honey.event
@@ -442,7 +442,7 @@ class LibhoneyResponseBlaster < Minitest::Test
 
     # ensure that the thread above is waiting for
     # an event to be pushed onto the queue
-    sleep 0.1 while t.status!='sleep'
+    sleep 0.1 while t.status != 'sleep'
 
     (1..@times_to_test).each do |i|
       event = @honey.event

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -362,12 +362,19 @@ class LibhoneyTest < Minitest::Test
 
     JSON.stub :generate, json_generate do
       t = Thread.new do
-        response = @honey.responses.pop
+        responses = []
+        while (response = @honey.responses.pop)
+          responses << response
+        end
+
+        assert_equal(2, responses.size)
+
+        response = responses[0]
         assert_equal(1, response.metadata)
         assert_kind_of(Exception, response.error)
         assert_kind_of(HTTP::Response::Status, response.status_code)
 
-        response = @honey.responses.pop
+        response = responses[1]
         assert_equal(2, response.metadata)
         assert_kind_of(HTTP::Response::Status, response.status_code)
       end
@@ -384,6 +391,7 @@ class LibhoneyTest < Minitest::Test
         event.send
       end
 
+      @honey.close
       t.join
     end
   end

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -427,7 +427,8 @@ class LibhoneyResponseBlaster < Minitest::Test
       pending_work_capacity: 1,
       max_batch_size: 1,
       max_concurrent_batches: 1,
-      send_frequency: 1)
+      send_frequency: 1
+    )
   end
 
   ##
@@ -437,27 +438,19 @@ class LibhoneyResponseBlaster < Minitest::Test
   #
   def test_response_queue_overload_subscriber
     events = 0
-    honey = Libhoney::Client.new(
-      writekey: 'mywritekey',
-      dataset: 'mydataset',
-      pending_work_capacity: 1,
-      max_batch_size: 1,
-      max_concurrent_batches: 1,
-      send_frequency: 1)
 
     t = Thread.new do
-      events += 1 while honey.responses.pop
+      events += 1 while @honey.responses.pop
     end
 
-
     (1..@times_to_test).each do |i|
-      event = honey.event
+      event = @honey.event
       event.dataset = 'mydataset-send'
       event.add('test' => i)
       sleep 1
       event.send
     end
-    honey.close
+    @honey.close
     t.join
   end
 


### PR DESCRIPTION
If the response queue is full when close is called and there is nothing waiting on the response queue then it causes a deadlock. Handle this by respecting the block_on_responses flag and suppressing the error raised when the queue is full.