### PR TITLE
Fix dependency on addressable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,10 @@ tag_filters: &tag_filters
         only: /.*/
 
 jobs:
+  ruby-2.2:
+    docker:
+      - image: circleci/ruby:2.2
+    steps: *test_steps
   ruby-2.3:
     docker:
       - image: circleci/ruby:2.3
@@ -65,12 +69,14 @@ workflows:
   version: 2
   build:
     jobs:
+      - ruby-2.2: *tag_filters
       - ruby-2.3: *tag_filters
       - ruby-2.4: *tag_filters
       - ruby-2.5: *tag_filters
       - ruby-2.6: *tag_filters
       - publish:
           requires:
+            - ruby-2.2
             - ruby-2.3
             - ruby-2.4
             - ruby-2.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     libhoney (1.13.6)
-      addressable (~> 2.0)
+      addressable (< 2.7)
       http (>= 2.0, < 5.0)
 
 GEM
@@ -18,7 +18,7 @@ GEM
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     hashdiff (1.0.0)
-    http (4.1.1)
+    http (4.0.0)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
       http-form_data (~> 2.0)
@@ -91,4 +91,4 @@ DEPENDENCIES
   yardstick (~> 0.9)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/libhoney.gemspec
+++ b/libhoney.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 3.4'
   spec.add_development_dependency 'yard'
   spec.add_development_dependency 'yardstick', '~> 0.9'
-  spec.add_dependency 'addressable', '~> 2.0'
+  spec.add_dependency 'addressable', '< 2.7'
   spec.add_dependency 'http', '>= 2.0', '< 5.0'
 end


### PR DESCRIPTION
Version 2.7 of addressable, bumped the major version that it supports of
public_suffix which it depends upon. Version 4 of public_suffix dropped
support for ruby 2.2 which libhoney-rb supports. Fixed libhoney to use
addressable < 2.7 so that we can continue to use the supported version
for ruby 2.2