### PR TITLE
Reduce Lock Contention

### DIFF
--- a/lib/libhoney/client.rb
+++ b/lib/libhoney/client.rb
@@ -216,7 +216,7 @@ module Libhoney
     # @param event [Event] the event to send to honeycomb
     # @api private
     def send_event(event)
-      @lock.synchronize do
+      @transmission ||= @lock.synchronize do
         transmission_client_params = {
           max_batch_size: @max_batch_size,
           send_frequency: @send_frequency,
@@ -229,7 +229,7 @@ module Libhoney
           proxy_config: @proxy_config
         }
 
-        @transmission ||= TransmissionClient.new(transmission_client_params)
+        TransmissionClient.new(transmission_client_params)
       end
 
       @transmission.add(event)


### PR DESCRIPTION
While attempting to test honeycomb in our application we experienced a significant throughput performance decrease. While attempting to identify the root cause I noticed the potential for lock contention during this `send_event`.

Since the lock is only necessary if the client needs to be initialized, this simply moves the short circuit to avoid using the lock when it's not needed.