### PR TITLE
Clean data for LogTransmissionClient

### DIFF
--- a/lib/libhoney/log_transmission.rb
+++ b/lib/libhoney/log_transmission.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'libhoney/cleaner'
 
 module Libhoney
   # For debugging use: a mock version of TransmissionClient that simply prints
@@ -9,6 +10,8 @@ module Libhoney
   #       to verify what events your instrumented code is sending. Use in
   #       production is not recommended.
   class LogTransmissionClient
+    include Cleaner
+
     def initialize(output:, verbose: false)
       @output  = output
       @verbose = verbose
@@ -21,7 +24,9 @@ module Libhoney
         metadata << " (sample rate: #{event.sample_rate})" if event.sample_rate != 1
         @output.print("#{metadata} | ")
       end
-      @output.puts(event.data.to_json)
+      clean_data(event.data).tap do |data|
+        @output.puts(data.to_json)
+      end
     end
 
     # Flushes the output (but does not close it)

--- a/test/log_transmission_test.rb
+++ b/test/log_transmission_test.rb
@@ -1,0 +1,12 @@
+require 'stringio'
+require 'libhoney/log_transmission'
+
+class LogTransmissionClientTest < Minitest::Test
+  def test_cleaned_output
+    stdout = StringIO.new
+    transmission = Libhoney::LogTransmissionClient.new(output: stdout)
+    data = { not_a_good_string: "\x89" }
+    transmission.add(OpenStruct.new(data: data))
+    assert_equal('{"not_a_good_string":"�"}', stdout.string.strip)
+  end
+end


### PR DESCRIPTION
When we added cleaning in #37 we missed adding it also to the `LogTransmissionClient`. This was pointed out in https://github.com/honeycombio/beeline-ruby/issues/41.