### PR TITLE
Use keyword splat to avoid deprecation warnings in ruby 2.7.0

### DIFF
--- a/lib/libhoney/cleaner.rb
+++ b/lib/libhoney/cleaner.rb
@@ -56,7 +56,7 @@ module Libhoney
     def clean_string(str)
       return str if str.encoding == Encoding::UTF_8 && str.valid_encoding?
 
-      str.encode(Encoding::UTF_8, ENCODING_OPTIONS)
+      str.encode(Encoding::UTF_8, **ENCODING_OPTIONS)
     end
   end
 end


### PR DESCRIPTION
Under ruby 2.7.0 I see _thousands_ of lines like this when using the gem:

```
libhoney-1.14.2/lib/libhoney/cleaner.rb:59: warning: Using the last argument as keyword parameters is deprecated
libhoney-1.14.2/lib/libhoney/cleaner.rb:59: warning: Using the last argument as keyword parameters is deprecated
libhoney-1.14.2/lib/libhoney/cleaner.rb:59: warning: Using the last argument as keyword parameters is deprecated
libhoney-1.14.2/lib/libhoney/cleaner.rb:59: warning: Using the last argument as keyword parameters is deprecated
libhoney-1.14.2/lib/libhoney/cleaner.rb:59: warning: Using the last argument as keyword parameters is deprecated
libhoney-1.14.2/lib/libhoney/cleaner.rb:59: warning: Using the last argument as keyword parameters is deprecated
libhoney-1.14.2/lib/libhoney/cleaner.rb:59: warning: Using the last argument as keyword parameters is deprecated
libhoney-1.14.2/lib/libhoney/cleaner.rb:59: warning: Using the last argument as keyword parameters is deprecated
libhoney-1.14.2/lib/libhoney/cleaner.rb:59: warning: Using the last argument as keyword parameters is deprecated
```

This operator has been available since ruby 2.0.0, so hopefully introducing it won't cause issues.