### PR TITLE
Remove ArgumentError exceptions from Transmission.

### DIFF
--- a/lib/libhoney/event.rb
+++ b/lib/libhoney/event.rb
@@ -121,8 +121,6 @@ module Libhoney
     #
     # @return [self] this event.
     def send_presampled
-      raise ArgumentError, "No metrics added to event. Won't send empty event." if data.empty?
-
       @libhoney.send_event(self)
       self
     end

--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -40,10 +40,6 @@ module Libhoney
     end
 
     def add(event)
-      raise ArgumentError, "No APIHost for Honeycomb. Can't send to the Great Unknown." if event.api_host == ''
-      raise ArgumentError, "No WriteKey specified. Can't send event."                   if event.writekey == ''
-      raise ArgumentError, "No Dataset for Honeycomb. Can't send datasetless."          if event.dataset  == ''
-
       begin
         @batch_queue.enq(event, !@block_on_send)
       rescue ThreadError


### PR DESCRIPTION
These lines are more harmful than useful. In the rare case that an event
is passed to the Transmission#add method without an api_host, dataset
or writekey, it's far preferable to let the HTTP call fail than to
rudely throw an exception, which could happen in a critical path of a
request, causing a user visible error.