### PR TITLE
flush events properly at low event throughputs

### DIFF
--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -138,6 +138,7 @@ module Libhoney
           while (event = Timeout.timeout(@send_frequency) { @batch_queue.pop })
             key = [event.api_host, event.writekey, event.dataset]
             batched_events[key] << event
+            break if Time.now > next_send_time
           end
 
           break


### PR DESCRIPTION
at low event throughput, the while loop in `batch_loop` that receives
events can fail to flush, because there's repeatedly a new event waiting
for it.

I verified this locally using `bundle open` and added a bunch of print
statements to `transmission.rb`.
Without this line, the while loop can sit for a long time, never
flushing any events out.

I have not yet dug into the test suite for this library to understand how to test/reproduce this issue