### PR TITLE
Handle interrupt

### DIFF
--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -135,9 +135,11 @@ module Libhoney
 
       loop do
         begin
-          while (event = Timeout.timeout(@send_frequency) { @batch_queue.pop })
-            key = [event.api_host, event.writekey, event.dataset]
-            batched_events[key] << event
+          Thread.handle_interrupt(Timeout::Error => :immediate) do
+            while (event = Timeout.timeout(@send_frequency) { @batch_queue.pop })
+              key = [event.api_host, event.writekey, event.dataset]
+              batched_events[key] << event
+            end
           end
 
           break

--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -135,7 +135,7 @@ module Libhoney
 
       loop do
         begin
-          Thread.handle_interrupt(Timeout::Error => :immediate) do
+          Thread.handle_interrupt(Timeout::Error => :on_blocking) do
             while (event = Timeout.timeout(@send_frequency) { @batch_queue.pop })
               key = [event.api_host, event.writekey, event.dataset]
               batched_events[key] << event

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -251,6 +251,24 @@ class LibhoneyTest < Minitest::Test
     assert_requested :post, 'https://api.honeycomb.io/1/batch/mydataset', times: 1
   end
 
+  def test_handle_interrupt
+    stub_request(:post, 'https://api.honeycomb.io/1/batch/interrupt')
+      .to_rack(HoneycombServer)
+
+    Thread.handle_interrupt(Timeout::Error => :never) do
+      (1..10).each do |i|
+        event = @honey.event
+        event.dataset = 'interrupt'
+        event.add('test' => i)
+        event.send
+      end
+    end
+
+    sleep 1
+
+    assert_requested :post, 'https://api.honeycomb.io/1/batch/interrupt', times: 1
+  end
+
   def test_close
     times_to_test = 900
 


### PR DESCRIPTION
It's possible to wrap the libhoney code in a way that causes the timeout interrupts not to fire. This is an experiment in how we could handle this