### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = false
+
+[*.md]
+indent_size = 4
+trim_trailing_whitespace = false


### PR DESCRIPTION
Adds a simple editor config for use with .rb and .md files (eg spaces over tabs).