### PR TITLE
Do not attempt to send invalid events

### DIFF
--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -40,7 +40,7 @@ module Libhoney
     end
 
     def add(event)
-      return if !event_valid(event)
+      return unless event_valid(event)
 
       begin
         @batch_queue.enq(event, !@block_on_send)
@@ -57,8 +57,9 @@ module Libhoney
       invalid.push('write key') if event.writekey.nil? || event.writekey.empty?
       invalid.push('dataset') if event.dataset.nil? || event.dataset.empty?
 
-      if !invalid.empty?
-        e = StandardError.new("#{self.class.name}: nil or empty required fields (#{invalid.join(', ')}). Will not attemot to send.")
+      unless invalid.empty?
+        e = StandardError.new("#{self.class.name}: nil or empty required fields (#{invalid.join(', ')})"\
+          ". Will not attemot to send.")
         Response.new(error: e).tap do |error_response|
           error_response.metadata = event.metadata
           enqueue_response(error_response)
@@ -67,7 +68,7 @@ module Libhoney
         return false
       end
 
-      return true
+      true
     end
 
     def send_loop

--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -59,7 +59,7 @@ module Libhoney
 
       unless invalid.empty?
         e = StandardError.new("#{self.class.name}: nil or empty required fields (#{invalid.join(', ')})"\
-          ". Will not attemot to send.")
+          '. Will not attemot to send.')
         Response.new(error: e).tap do |error_response|
           error_response.metadata = event.metadata
           enqueue_response(error_response)

--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -59,7 +59,7 @@ module Libhoney
 
       unless invalid.empty?
         e = StandardError.new("#{self.class.name}: nil or empty required fields (#{invalid.join(', ')})"\
-          '. Will not attemot to send.')
+          '. Will not attempt to send.')
         Response.new(error: e).tap do |error_response|
           error_response.metadata = event.metadata
           enqueue_response(error_response)

--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -40,6 +40,8 @@ module Libhoney
     end
 
     def add(event)
+      return if !event_valid(event)
+
       begin
         @batch_queue.enq(event, !@block_on_send)
       rescue ThreadError
@@ -47,6 +49,25 @@ module Libhoney
       end
 
       ensure_threads_running
+    end
+
+    def event_valid(event)
+      invalid = []
+      invalid.push('api host') if event.api_host.nil? || event.api_host.empty?
+      invalid.push('write key') if event.writekey.nil? || event.writekey.empty?
+      invalid.push('dataset') if event.dataset.nil? || event.dataset.empty?
+
+      if !invalid.empty?
+        e = StandardError.new("#{self.class.name}: nil or empty required fields (#{invalid.join(', ')}). Will not attemot to send.")
+        Response.new(error: e).tap do |error_response|
+          error_response.metadata = event.metadata
+          enqueue_response(error_response)
+        end
+
+        return false
+      end
+
+      return true
     end
 
     def send_loop

--- a/test/transmission_test.rb
+++ b/test/transmission_test.rb
@@ -20,7 +20,8 @@ class TransmissionClientTest < Minitest::Test
     assert(!e.nil?)
     assert(!e.error.nil?)
     assert_equal('Libhoney::TransmissionClient: nil or empty required fields (api host, write key, dataset).'\
-      ' Will not attemot to send.', e.error.message)  end
+      ' Will not attemot to send.', e.error.message)
+  end
 
   def test_event_with_empty_required_fields_is_rejected
     mock_builder = Minitest::Mock.new

--- a/test/transmission_test.rb
+++ b/test/transmission_test.rb
@@ -17,8 +17,8 @@ class TransmissionClientTest < Minitest::Test
     # check event added to repsonse queue
     assert_equal(1, response_queue.length)
     e = response_queue.pop
-    assert(!e.nil?)
-    assert(!e.error.nil?)
+    refute_nil(e)
+    refute_nil(e.error)
     assert_equal('Libhoney::TransmissionClient: nil or empty required fields (api host, write key, dataset).'\
       ' Will not attemot to send.', e.error.message)
   end

--- a/test/transmission_test.rb
+++ b/test/transmission_test.rb
@@ -20,7 +20,7 @@ class TransmissionClientTest < Minitest::Test
     refute_nil(e)
     refute_nil(e.error)
     assert_equal('Libhoney::TransmissionClient: nil or empty required fields (api host, write key, dataset).'\
-      ' Will not attemot to send.', e.error.message)
+      ' Will not attempt to send.', e.error.message)
   end
 
   def test_event_with_empty_required_fields_is_rejected
@@ -42,6 +42,6 @@ class TransmissionClientTest < Minitest::Test
     refute_nil(e)
     refute_nil(e.error)
     assert_equal('Libhoney::TransmissionClient: nil or empty required fields (api host, write key, dataset).'\
-      ' Will not attemot to send.', e.error.message)
+      ' Will not attempt to send.', e.error.message)
   end
 end

--- a/test/transmission_test.rb
+++ b/test/transmission_test.rb
@@ -39,8 +39,8 @@ class TransmissionClientTest < Minitest::Test
     # check event added to repsonse queue
     assert_equal(1, response_queue.length)
     e = response_queue.pop
-    assert(!e.nil?)
-    assert(!e.error.nil?)
+    refute_nil(e)
+    refute_nil(e.error)
     assert_equal('Libhoney::TransmissionClient: nil or empty required fields (api host, write key, dataset).'\
       ' Will not attemot to send.', e.error.message)
   end

--- a/test/transmission_test.rb
+++ b/test/transmission_test.rb
@@ -19,15 +19,15 @@ class TransmissionClientTest < Minitest::Test
     e = response_queue.pop
     assert(!e.nil?)
     assert(!e.error.nil?)
-    assert_equal('Libhoney::TransmissionClient: nil or empty required fields (api host, write key, dataset). Will not attemot to send.', e.error.message)
-  end
+    assert_equal('Libhoney::TransmissionClient: nil or empty required fields (api host, write key, dataset).'\
+      ' Will not attemot to send.', e.error.message)  end
 
   def test_event_with_empty_required_fields_is_rejected
     mock_builder = Minitest::Mock.new
-    mock_builder.expect :writekey, ""
-    mock_builder.expect :dataset, ""
-    mock_builder.expect :sample_rate, ""
-    mock_builder.expect :api_host, ""
+    mock_builder.expect :writekey, ''
+    mock_builder.expect :dataset, ''
+    mock_builder.expect :sample_rate, ''
+    mock_builder.expect :api_host, ''
     mock_builder.expect :metadata, nil
     event = Libhoney::Event.new(nil, mock_builder)
 
@@ -40,6 +40,7 @@ class TransmissionClientTest < Minitest::Test
     e = response_queue.pop
     assert(!e.nil?)
     assert(!e.error.nil?)
-    assert_equal('Libhoney::TransmissionClient: nil or empty required fields (api host, write key, dataset). Will not attemot to send.', e.error.message)
+    assert_equal('Libhoney::TransmissionClient: nil or empty required fields (api host, write key, dataset).'\
+      ' Will not attemot to send.', e.error.message)
   end
 end

--- a/test/transmission_test.rb
+++ b/test/transmission_test.rb
@@ -1,14 +1,14 @@
 require 'libhoney'
 
 class TransmissionClientTest < Minitest::Test
-  def test_event_with_empty_required_fields_is_rejected
-    mockBuilder = Minitest::Mock.new()
-    mockBuilder.expect :writekey, nil
-    mockBuilder.expect :dataset, nil
-    mockBuilder.expect :sample_rate, nil
-    mockBuilder.expect :api_host, nil
-    mockBuilder.expect :metadata, nil
-    event = Libhoney::Event.new(nil, mockBuilder)
+  def test_event_with_nil_required_fields_is_rejected
+    mock_builder = Minitest::Mock.new
+    mock_builder.expect :writekey, nil
+    mock_builder.expect :dataset, nil
+    mock_builder.expect :sample_rate, nil
+    mock_builder.expect :api_host, nil
+    mock_builder.expect :metadata, nil
+    event = Libhoney::Event.new(nil, mock_builder)
 
     response_queue = SizedQueue.new(10)
     transmission = Libhoney::TransmissionClient.new(responses: response_queue)
@@ -17,19 +17,19 @@ class TransmissionClientTest < Minitest::Test
     # check event added to repsonse queue
     assert_equal(1, response_queue.length)
     e = response_queue.pop
-    assert(e != nil)
-    assert(e.error != nil)
+    assert(!e.nil?)
+    assert(!e.error.nil?)
     assert_equal('Libhoney::TransmissionClient: nil or empty required fields (api host, write key, dataset). Will not attemot to send.', e.error.message)
   end
 
   def test_event_with_empty_required_fields_is_rejected
-    mockBuilder = Minitest::Mock.new()
-    mockBuilder.expect :writekey, ""
-    mockBuilder.expect :dataset, ""
-    mockBuilder.expect :sample_rate, ""
-    mockBuilder.expect :api_host, ""
-    mockBuilder.expect :metadata, nil
-    event = Libhoney::Event.new(nil, mockBuilder)
+    mock_builder = Minitest::Mock.new
+    mock_builder.expect :writekey, ""
+    mock_builder.expect :dataset, ""
+    mock_builder.expect :sample_rate, ""
+    mock_builder.expect :api_host, ""
+    mock_builder.expect :metadata, nil
+    event = Libhoney::Event.new(nil, mock_builder)
 
     response_queue = SizedQueue.new(10)
     transmission = Libhoney::TransmissionClient.new(responses: response_queue)
@@ -38,8 +38,8 @@ class TransmissionClientTest < Minitest::Test
     # check event added to repsonse queue
     assert_equal(1, response_queue.length)
     e = response_queue.pop
-    assert(e != nil)
-    assert(e.error != nil)
+    assert(!e.nil?)
+    assert(!e.error.nil?)
     assert_equal('Libhoney::TransmissionClient: nil or empty required fields (api host, write key, dataset). Will not attemot to send.', e.error.message)
   end
 end

--- a/test/transmission_test.rb
+++ b/test/transmission_test.rb
@@ -1,0 +1,45 @@
+require 'libhoney'
+
+class TransmissionClientTest < Minitest::Test
+  def test_event_with_empty_required_fields_is_rejected
+    mockBuilder = Minitest::Mock.new()
+    mockBuilder.expect :writekey, nil
+    mockBuilder.expect :dataset, nil
+    mockBuilder.expect :sample_rate, nil
+    mockBuilder.expect :api_host, nil
+    mockBuilder.expect :metadata, nil
+    event = Libhoney::Event.new(nil, mockBuilder)
+
+    response_queue = SizedQueue.new(10)
+    transmission = Libhoney::TransmissionClient.new(responses: response_queue)
+    transmission.add(event)
+
+    # check event added to repsonse queue
+    assert_equal(1, response_queue.length)
+    e = response_queue.pop
+    assert(e != nil)
+    assert(e.error != nil)
+    assert_equal('Libhoney::TransmissionClient: nil or empty required fields (api host, write key, dataset). Will not attemot to send.', e.error.message)
+  end
+
+  def test_event_with_empty_required_fields_is_rejected
+    mockBuilder = Minitest::Mock.new()
+    mockBuilder.expect :writekey, ""
+    mockBuilder.expect :dataset, ""
+    mockBuilder.expect :sample_rate, ""
+    mockBuilder.expect :api_host, ""
+    mockBuilder.expect :metadata, nil
+    event = Libhoney::Event.new(nil, mockBuilder)
+
+    response_queue = SizedQueue.new(10)
+    transmission = Libhoney::TransmissionClient.new(responses: response_queue)
+    transmission.add(event)
+
+    # check event added to repsonse queue
+    assert_equal(1, response_queue.length)
+    e = response_queue.pop
+    assert(e != nil)
+    assert(e.error != nil)
+    assert_equal('Libhoney::TransmissionClient: nil or empty required fields (api host, write key, dataset). Will not attemot to send.', e.error.message)
+  end
+end


### PR DESCRIPTION
Each event sent to Honeycomb requires a valid (not nil or empty) api host, writekey and dataset. This change fast-fails events that are invalid and adds an entry to the response_queue.

Supersedes https://github.com/honeycombio/beeline-ruby/pull/118