### PR TITLE
Update .editorconfig to add new lines to end of files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ indent_style = space
 indent_size = 2
 charset = utf-8
 trim_trailing_whitespace = true
-insert_final_newline = false
+insert_final_newline = true
 
 [*.md]
 indent_size = 4


### PR DESCRIPTION
Rubocop requires new lines at the end of all .rb files but the .editorconfig did not automatically apply them. This change updates the config to automatically insert new lines on save.