### PR TITLE
unroll Class monkeypatching

### DIFF
--- a/lib/libhoney/client.rb
+++ b/lib/libhoney/client.rb
@@ -1,6 +1,7 @@
 require 'time'
 require 'json'
 require 'http'
+require 'forwardable'
 
 require 'libhoney/null_transmission'
 
@@ -30,6 +31,8 @@ module Libhoney
   #   evt.send
   #
   class Client
+    extend Forwardable
+
     API_HOST = 'https://api.honeycomb.io/'.freeze
 
     # Instantiates libhoney and prepares it to send events to Honeycomb.
@@ -106,45 +109,8 @@ module Libhoney
                 :send_frequency, :max_concurrent_batches,
                 :pending_work_capacity, :responses
 
-    def event
-      @builder.event
-    end
-
-    def writekey
-      @builder.writekey
-    end
-
-    def dataset
-      @builder.dataset
-    end
-
-    def sample_rate
-      @builder.sample_rate
-    end
-
-    def api_host
-      @builder.api_host
-    end
-
-    def writekey=(val)
-      @builder.writekey = val
-    end
-
-    def dataset=(val)
-      @builder.dataset = val
-    end
-
-    def sample_rate=(val)
-      @builder.sample_rate = val
-    end
-
-    def api_host=(val)
-      @builder.api_host = val
-    end
-
-    def builder(fields = {}, dyn_fields = {})
-      @builder.builder(fields, dyn_fields)
-    end
+    def_delegators :@builder, :event, :writekey, :writekey=, :dataset, :dataset=,
+                   :sample_rate, :sample_rate=, :api_host, :api_host=, :builder
 
     # Nuke the queue and wait for inflight requests to complete before returning.
     # If you set drain=false, all queued requests will be dropped on the floor.

--- a/lib/libhoney/client.rb
+++ b/lib/libhoney/client.rb
@@ -4,28 +4,6 @@ require 'http'
 
 require 'libhoney/null_transmission'
 
-# Define a few additions that proxy access through Client's builder. Makes Client much tighter.
-class Class
-  def builder_attr_accessor(*args)
-    args.each do |arg|
-      class_eval("def #{arg};@builder.#{arg};end", __FILE__, __LINE__)
-      class_eval("def #{arg}=(val);@builder.#{arg}=val;end", __FILE__, __LINE__)
-    end
-  end
-
-  def builder_attr_reader(*args)
-    args.each do |arg|
-      class_eval("def #{arg};@builder.#{arg};end", __FILE__, __LINE__)
-    end
-  end
-
-  def builder_attr_writer(*args)
-    args.each do |arg|
-      class_eval("def #{arg}=(val);@builder.#{arg}=val;end", __FILE__, __LINE__)
-    end
-  end
-end
-
 module Libhoney
   ##
   # This is a library to allow you to send events to Honeycomb from within your
@@ -124,14 +102,44 @@ module Libhoney
       @proxy_config           = proxy_config
     end
 
-    builder_attr_accessor :writekey, :dataset, :sample_rate, :api_host
-
     attr_reader :block_on_send, :block_on_responses, :max_batch_size,
                 :send_frequency, :max_concurrent_batches,
                 :pending_work_capacity, :responses
 
     def event
       @builder.event
+    end
+
+    def writekey
+      @builder.writekey
+    end
+
+    def dataset
+      @builder.dataset
+    end
+
+    def sample_rate
+      @builder.sample_rate
+    end
+
+    def api_host
+      @builder.api_host
+    end
+
+    def writekey=(val)
+      @builder.writekey = val
+    end
+
+    def dataset=(val)
+      @builder.dataset = val
+    end
+
+    def sample_rate=(val)
+      @builder.sample_rate = val
+    end
+
+    def api_host=(val)
+      @builder.api_host = val
     end
 
     def builder(fields = {}, dyn_fields = {})


### PR DESCRIPTION
Unrolling some extensions to the base ruby `Class`.

These extensions, while defined in `/lib/libhoney/client.rb` and only used in that one library, extend to the entire Ruby runtime environment, and by extension every object created by any Ruby code which includes this library.

It's our view that this approach is overkill for the purposes of saving a few lines of boilerplate, and moreover their usage of `class_eval` poses an unnecessary security risk.