### PR TITLE
only join and run the batch thread if it exists

### DIFF
--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -136,7 +136,7 @@ module Libhoney
       end
 
       @batch_queue.enq(nil)
-      @batch_thread.join
+      @batch_thread.join unless @batch_thread.nil?
 
       # send @threads.length number of nils so each thread will fall out of send_loop
       @threads.length.times { @send_queue << nil }


### PR DESCRIPTION
In a Rails 4.2 app, when I run `bundle exec rake assets:precompile` I get the following error:

```
I, [2020-11-30T19:07:05.503140 #1]  INFO -- : Writing /app/public/assets/reports/application-e80e8f2318043e8af94dddc2adad5a4f09739a8ebb323b3ab31cd71d45fd9113.css.gz
/app/vendor/bundle/ruby/2.3.0/gems/libhoney-1.16.0/lib/libhoney/transmission.rb:139:in `close': undefined method `join' for nil:NilClass (NoMethodError)
        from /app/vendor/bundle/ruby/2.3.0/gems/libhoney-1.16.0/lib/libhoney/client.rb:118:in `close'
        from /app/vendor/bundle/ruby/2.3.0/gems/honeycomb-beeline-2.3.0/lib/honeycomb/client.rb:45:in `block in initialize'
```

This patch avoid calling `@batch_thread.join` if `@batch_thread` is nil, which is how it's initialized.