### PR TITLE
add test for closing transmission when no threads have been started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # libhoney-rb changelog
 
+## changes pending release
+
+- Fix closing down the client when no threads have been started. (#74 & #76)
+
 ## 1.16.0
 
 ### Fixes:

--- a/test/transmission_test.rb
+++ b/test/transmission_test.rb
@@ -44,4 +44,10 @@ class TransmissionClientTest < Minitest::Test
     assert_equal('Libhoney::TransmissionClient: nil or empty required fields (api host, write key, dataset).'\
       ' Will not attempt to send.', e.error.message)
   end
+
+  def test_closing_does_not_error_when_no_threads_have_been_created
+    transmission = Libhoney::TransmissionClient.new
+    drain = true
+    transmission.close(drain) # implicit assertion that this does not raise an error and fail the test
+  end
 end


### PR DESCRIPTION
A test for #74.

If the libhoney client is instantiated, but never started or an event is not added, on process exit transmission throws an error when closing.

    NoMethodError (undefined method `join' for nil:NilClass) in 'close'

This behavior was seen in a Rails application running rake tasks that initialize the entire app, but does not start or queue any events before the process exits.