### PR TITLE
Allow ruby 3.0.0

### DIFF
--- a/lib/libhoney/client.rb
+++ b/lib/libhoney/client.rb
@@ -70,7 +70,7 @@ module Libhoney
       raise Exception, 'libhoney:  max_concurrent_batches must be greater than 0' if max_concurrent_batches < 1
       raise Exception, 'libhoney:  sample rate must be greater than 0'            if sample_rate < 1
 
-      unless Gem::Dependency.new('ruby', '~> 2.2').match?('ruby', RUBY_VERSION)
+      unless Gem::Dependency.new('ruby', '> 2.2').match?('ruby', RUBY_VERSION)
         raise Exception, 'libhoney:  Ruby versions < 2.2 are not supported'
       end
 

--- a/lib/libhoney/client.rb
+++ b/lib/libhoney/client.rb
@@ -70,7 +70,7 @@ module Libhoney
       raise Exception, 'libhoney:  max_concurrent_batches must be greater than 0' if max_concurrent_batches < 1
       raise Exception, 'libhoney:  sample rate must be greater than 0'            if sample_rate < 1
 
-      unless Gem::Dependency.new('ruby', '> 2.2').match?('ruby', RUBY_VERSION)
+      unless Gem::Dependency.new('ruby', '>= 2.2').match?('ruby', RUBY_VERSION)
         raise Exception, 'libhoney:  Ruby versions < 2.2 are not supported'
       end
 


### PR DESCRIPTION
Ruby 3.0 can't be used with this gem right now, because it doesn't match the restriction.
This updates that restriction to really allow anything > 2.2.