### PR TITLE
Prepare v1.17.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## changes pending release
 
+## 1.17.0
+
+### Fixes:
+
+- Allow Ruby 3.0.0 (removes overly-pessimistic exception) (#79)
+
 ## 1.16.1
 
 ### Fixes:

--- a/lib/libhoney/version.rb
+++ b/lib/libhoney/version.rb
@@ -1,3 +1,3 @@
 module Libhoney
-  VERSION = '1.16.1'.freeze
+  VERSION = '1.17.0'.freeze
 end


### PR DESCRIPTION
- Allow Ruby 3.0.0 (removes overly-pessimistic exception) (#79)