### PR TITLE
replace HTTP client library to reduce external dependencies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,7 @@ Metrics/BlockLength:
 Metrics/ClassLength:
   Max: 200
   Exclude:
+    - lib/libhoney/transmission.rb # Should this remain so large?
     - test/*
 
 Metrics/MethodLength:

--- a/lib/libhoney/client.rb
+++ b/lib/libhoney/client.rb
@@ -1,3 +1,4 @@
+require 'addressable/uri'
 require 'time'
 require 'json'
 require 'forwardable'
@@ -50,6 +51,13 @@ module Libhoney
     # @param block_on_responses [Boolean] if true, block if there is no thread reading from the response queue
     # @param pending_work_capacity [Fixnum] defaults to 1000. If the queue of
     #   pending events exceeds 1000, this client will start dropping events.
+    # @param proxy_config [String, Array, nil] proxy connection information
+    #   nil: (default, recommended) connection proxying will be determined from any http_proxy, https_proxy, and no_proxy environment
+    #     variables set for the process.
+    #   String: the value must be the URI for connecting to a forwarding web proxy. Must be parsable by stdlib URI.
+    #   Array: (deprecated, removal in v2.0) the value must have one and at most four elements: e.g. ['host', port, 'username', 'password'].
+    #     The assumption is that the TCP connection will be tunneled via HTTP, so the assumed scheme is 'http://'
+    #     'host' is required. 'port' is optional (default:80), unless a 'username' is included. 'password' is optional.
     # rubocop:disable Metrics/ParameterLists
     def initialize(writekey: nil,
                    dataset: nil,
@@ -101,7 +109,7 @@ module Libhoney
       @pending_work_capacity  = pending_work_capacity
       @responses              = SizedQueue.new(2 * @pending_work_capacity)
       @lock                   = Mutex.new
-      @proxy_config           = proxy_config
+      @proxy_config           = parse_proxy_config(proxy_config)
     end
 
     attr_reader :block_on_send, :block_on_responses, :max_batch_size,
@@ -222,6 +230,34 @@ module Libhoney
     # @api private
     def should_drop(sample_rate)
       rand(1..sample_rate) != 1
+    end
+
+    # @api private
+    def parse_proxy_config(config)
+      case config
+      when nil; nil
+      when String
+        URI.parse(config)
+      when Array
+        warn <<~WARNING
+          DEPRECATION WARNING: #{self.class.name} the proxy_config parameter will require a String value, not an Array in libhoney 2.0.
+          To resolve:
+            + recommended: set http/https_proxy environment variables, which take precedence over any option set here, then remove proxy_config parameter from client initialization
+            + set proxy_config to a String containing the forwarding proxy URI (only used if http/https_proxy are not set)
+        WARNING
+        host, port, user, password = config
+
+        parsed_config = URI::HTTP.build(host: host, port: port).tap do |uri|
+          uri.userinfo = "#{user}:#{password}" if user
+        end
+        redacted_config = parsed_config.dup.tap do |uri|
+          uri.password = "REDACTED" unless (uri.password.nil? || uri.password.empty?)
+        end
+        warn "The array config given has been assumed to mean: #{redacted_config}"
+        parsed_config
+      end
+    rescue URI::Error => error
+      warn "#{self.class.name}: unable to parse proxy_config. Detail: #{error.class}: #{error.message}"
     end
   end
 end

--- a/lib/libhoney/client.rb
+++ b/lib/libhoney/client.rb
@@ -232,6 +232,8 @@ module Libhoney
       rand(1..sample_rate) != 1
     end
 
+    private
+
     # @api private
     def parse_proxy_config(config)
       case config

--- a/lib/libhoney/client.rb
+++ b/lib/libhoney/client.rb
@@ -235,15 +235,15 @@ module Libhoney
     # @api private
     def parse_proxy_config(config)
       case config
-      when nil; nil
+      when nil then nil
       when String
         URI.parse(config)
       when Array
-        warn <<~WARNING
-          DEPRECATION WARNING: #{self.class.name} the proxy_config parameter will require a String value, not an Array in libhoney 2.0.
-          To resolve:
-            + recommended: set http/https_proxy environment variables, which take precedence over any option set here, then remove proxy_config parameter from client initialization
-            + set proxy_config to a String containing the forwarding proxy URI (only used if http/https_proxy are not set)
+        warn <<-WARNING
+        DEPRECATION WARNING: #{self.class.name} the proxy_config parameter will require a String value, not an Array in libhoney 2.0.
+        To resolve:
+          + recommended: set http/https_proxy environment variables, which take precedence over any option set here, then remove proxy_config parameter from client initialization
+          + set proxy_config to a String containing the forwarding proxy URI (only used if http/https_proxy are not set)
         WARNING
         host, port, user, password = config
 
@@ -251,13 +251,13 @@ module Libhoney
           uri.userinfo = "#{user}:#{password}" if user
         end
         redacted_config = parsed_config.dup.tap do |uri|
-          uri.password = "REDACTED" unless (uri.password.nil? || uri.password.empty?)
+          uri.password = 'REDACTED' unless uri.password.nil? || uri.password.empty?
         end
         warn "The array config given has been assumed to mean: #{redacted_config}"
         parsed_config
       end
-    rescue URI::Error => error
-      warn "#{self.class.name}: unable to parse proxy_config. Detail: #{error.class}: #{error.message}"
+    rescue URI::Error => e
+      warn "#{self.class.name}: unable to parse proxy_config. Detail: #{e.class}: #{e.message}"
     end
   end
 end

--- a/lib/libhoney/client.rb
+++ b/lib/libhoney/client.rb
@@ -1,6 +1,5 @@
 require 'time'
 require 'json'
-require 'http'
 require 'forwardable'
 
 require 'libhoney/null_transmission'

--- a/lib/libhoney/response.rb
+++ b/lib/libhoney/response.rb
@@ -1,5 +1,3 @@
-require 'http'
-
 module Libhoney
   class Response
     attr_accessor :duration, :status_code, :metadata, :error
@@ -9,7 +7,7 @@ module Libhoney
                    metadata: nil,
                    error: nil)
       @duration    = duration
-      @status_code = HTTP::Response::Status.new(status_code)
+      @status_code = status_code
       @metadata    = metadata
       @error       = error
     end

--- a/lib/libhoney/response.rb
+++ b/lib/libhoney/response.rb
@@ -1,5 +1,15 @@
+require 'http/response/status'
+
 module Libhoney
   class Response
+    # The response status from HTTP calls to a Honeycomb API endpoint.
+    #
+    # For most of the life of this client, this response object has been
+    # a pass-through to the underlying HTTP library's response object.
+    # This class in the Libhoney namespace now owns the interface for
+    # API responses.
+    class Status < HTTP::Response::Status; end
+
     attr_accessor :duration, :status_code, :metadata, :error
 
     def initialize(duration: 0,
@@ -7,7 +17,7 @@ module Libhoney
                    metadata: nil,
                    error: nil)
       @duration    = duration
-      @status_code = status_code
+      @status_code = Status.new(status_code)
       @metadata    = metadata
       @error       = error
     end

--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -105,6 +105,8 @@ module Libhoney
           # because this is effectively the top-level exception handler for the
           # sender threads, and we don't want those threads to die (leaving
           # nothing consuming the queue).
+          warn "#{self.class.name}: 💥 " + e.message if ['debug', 'trace'].include?(ENV["LOG_LEVEL"])
+          warn e.backtrace.join("\n").to_s if ['trace'].include?(ENV["LOG_LEVEL"])
           begin
             batch.each do |event|
               # nil events in the batch should already have had an error

--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -105,8 +105,8 @@ module Libhoney
           # because this is effectively the top-level exception handler for the
           # sender threads, and we don't want those threads to die (leaving
           # nothing consuming the queue).
-          warn "#{self.class.name}: 💥 " + e.message if ['debug', 'trace'].include?(ENV["LOG_LEVEL"])
-          warn e.backtrace.join("\n").to_s if ['trace'].include?(ENV["LOG_LEVEL"])
+          warn "#{self.class.name}: 💥 " + e.message if %w[debug trace].include?(ENV['LOG_LEVEL'])
+          warn e.backtrace.join("\n").to_s if ['trace'].include?(ENV['LOG_LEVEL'])
           begin
             batch.each do |event|
               # nil events in the batch should already have had an error
@@ -270,7 +270,7 @@ module Libhoney
           headers: {
             'User-Agent' => @user_agent,
             'Content-Type' => 'application/json'
-          },
+          }
         )
 
         h[api_host] = client

--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -258,24 +258,13 @@ module Libhoney
 
     def build_http_clients
       Hash.new do |h, api_host|
-        if @proxy_config
-          host, port, user, pass = @proxy_config
-          userinfo = "#{user}:#{pass}" if user
-          # TODO: http.rb doesn't include scheme, is this always HTTPS?
-          proxy = URI::HTTPS.build(
-            host: host,
-            port: port,
-            userinfo: userinfo,
-          ).to_s
-        end
-
         client = ::Excon.new(
           api_host,
           persistent: true,
           read_timeout: @send_timeout,
           write_timeout: @send_timeout,
           connect_timeout: @send_timeout,
-          proxy: proxy,
+          proxy: @proxy_config,
           headers: {
             'User-Agent' => @user_agent,
             'Content-Type' => 'application/json'

--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -1,3 +1,5 @@
+require 'addressable/uri'
+require 'excon'
 require 'json'
 require 'timeout'
 require 'libhoney/response'
@@ -267,7 +269,7 @@ module Libhoney
           ).to_s
         end
 
-        client = Excon.new(
+        client = ::Excon.new(
           api_host,
           persistent: true,
           read_timeout: @send_timeout,

--- a/libhoney.gemspec
+++ b/libhoney.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard'
   spec.add_development_dependency 'yardstick', '~> 0.9'
   spec.add_dependency 'addressable', '~> 2.0'
-  spec.add_dependency 'http', '>= 2.0', '< 5.0'
+  spec.add_dependency 'excon'
 end

--- a/libhoney.gemspec
+++ b/libhoney.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yardstick', '~> 0.9'
   spec.add_dependency 'addressable', '~> 2.0'
   spec.add_dependency 'excon'
+  spec.add_dependency 'http', '>= 2.0', '< 5.0'
 end

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -69,9 +69,9 @@ end
 
 class LibhoneyProxyTest < Minitest::Test
   def test_send_now_with_proxy
-    stub_request(:post, 'http://example.com/1/batch/dataset').
-      with(headers: { 'Proxy-Authorization' => /^Basic / }).
-      to_rack(HoneycombServer)
+    stub_request(:post, 'http://example.com/1/batch/dataset')
+      .with(headers: { 'Proxy-Authorization' => /^Basic / })
+      .to_rack(HoneycombServer)
 
     honey = Libhoney::Client.new(writekey: 'writekey',
                                  dataset: 'dataset',
@@ -103,7 +103,7 @@ class LibhoneyProxyConfigArrayParsingTest < Minitest::Test
   def test_proxy_config_array_parsing_removed_in_v2
     assert(
       Gem::Version.new(Libhoney::VERSION) < Gem::Version.new('2.0'),
-      "DEPRECATION: The parsing of an Array passed as proxy_config and this test class should be removed in the 2.0 release."
+      'DEPRECATION: Array passed as proxy_config and this test class should be removed in the 2.0 release.'
     )
   end
 
@@ -115,9 +115,18 @@ class LibhoneyProxyConfigArrayParsingTest < Minitest::Test
     )
 
     assert_equal 'http://proxy-hostname.local', honey.instance_variable_get(:@proxy_config).to_s
-    assert_match(/DEPRECATION WARNING.*proxy_config/, $stderr.string, 'should log a deprecation warning about proxy_config')
-    assert_match(/set http\/https_proxy/, $stderr.string, 'should recommend using environment variables')
-    assert_match(/set proxy_config to a String/, $stderr.string, 'should recommend using a string value for proxy_config')
+    assert_match(
+      /DEPRECATION WARNING.*proxy_config/, $stderr.string,
+      'should log a deprecation warning about proxy_config'
+    )
+    assert_match(
+      %r{set http/https_proxy}, $stderr.string,
+      'should recommend using environment variables'
+    )
+    assert_match(
+      /set proxy_config to a String/, $stderr.string,
+      'should recommend using a string value for proxy_config'
+    )
   end
 
   def test_proxy_config_array_parsing_with_basic_auth
@@ -140,7 +149,6 @@ class LibhoneyProxyConfigArrayParsingTest < Minitest::Test
     Libhoney::Client.new(proxy_config: ['proxy-hostname.local', 'username'])
     assert_match(/unable to parse proxy_config/, $stderr.string, 'should warn when proxy_config is not parsable')
   end
-
 end
 
 class LibhoneyBuilderTest < Minitest::Test

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -91,7 +91,7 @@ end
 
 class LibhoneyProxyConfigArrayParsingTest < Minitest::Test
   def setup
-    # intercept warning emitted for missing writekey
+    # intercept deprecation warning to test its display
     @old_stderr = $stderr
     $stderr = StringIO.new
   end


### PR DESCRIPTION
Resolves #75 

Per [the proposal on #75](https://github.com/honeycombio/libhoney-rb/issues/75#issuecomment-755428264), this swaps out http.rb in favor for excon as the underlying HTTP client library for sending events.

The interfaces all remain the same. Excon handled proxy configuration differently than http.rb, so some array parsing has been added to handle what will now become the "legacy" proxy configuration format. The array-style proxy_config is deprecated in this change with the intent to remove in the next major version (2.0).

There's a fair amount that has changed here, so I recommend walking the commits to review related changes along with commentary left in the commit messages.