### PR TITLE
add a test_helper, Minitest reporters, & store test results in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,8 @@ jobs:
       - run:
           name: run tests
           command: bundle exec rake test
+      - store_test_results:
+          path: test/reports
 
   build_artifacts:
     executor:

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /pkg/
 /spec/reports/
 /spec/examples.txt
+/test/reports/
 /test/tmp/
 /test/version_tmp/
 /tmp/

--- a/libhoney.gemspec
+++ b/libhoney.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bump', '~> 0.5'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'minitest-reporters'
   spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'rubocop', '< 0.69'
   spec.add_development_dependency 'sinatra'

--- a/test/cleaner_test.rb
+++ b/test/cleaner_test.rb
@@ -1,4 +1,4 @@
-require 'minitest/autorun'
+require 'test_helper'
 require 'minitest/mock'
 require 'libhoney'
 require 'libhoney/cleaner'

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -1,6 +1,6 @@
+require 'test_helper'
 require 'json'
 require 'stringio'
-require 'minitest/autorun'
 require 'minitest/mock'
 require 'libhoney'
 require 'webmock/minitest'
@@ -547,7 +547,7 @@ class LibhoneyResponseBlaster < Minitest::Test
 
     # ensure that the thread above is waiting for
     # an event to be pushed onto the queue
-    sleep 0.1 while t.status != 'sleep'
+    test_waits_for { t.status == 'sleep' }
 
     (1..@times_to_test).each do |i|
       event = @honey.event

--- a/test/log_transmission_test.rb
+++ b/test/log_transmission_test.rb
@@ -1,3 +1,4 @@
+require 'test_helper'
 require 'stringio'
 require 'libhoney/log_transmission'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,9 @@
+require 'minitest/autorun'
+require 'minitest/reporters'
+Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new, Minitest::Reporters::JUnitReporter.new]
+
+def test_waits_for(timeout = 1)
+  Timeout.timeout timeout do
+    sleep 0.001 until yield
+  end
+end

--- a/test/test_test.rb
+++ b/test/test_test.rb
@@ -1,3 +1,4 @@
+require 'test_helper'
 require 'libhoney'
 
 # Tests for TestClient, which provides support for testing instrumented code.

--- a/test/transmission_test.rb
+++ b/test/transmission_test.rb
@@ -1,3 +1,4 @@
+require 'test_helper'
 require 'libhoney'
 
 class TransmissionClientTest < Minitest::Test


### PR DESCRIPTION
(Test suite improvements extracted from #87)

New dev dependency on minitest-reporters for more informative output (for example, individual test timing). Enable both Spec and JUnit test output in the test_helper for default. Tell git to ignore those JUnit XML files.

Update all test files to require the new test_helper which:

+ requires minitest/autorun so that each test file can be run standalone
+ enable Minitest::Reporters
+ adds `test_waits_for` to reuse whenever we're waiting for something to achieve a desired state, particularly for waiting for threads; also makes the wait time configurable

`test_waits_for` provides a tighter sleep loop so that we wait as short a time as possible.