### PR TITLE
Handle Timeout::Error in TransmissionClient

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -10,3 +10,4 @@ Eben Freeman <eben@honeycomb.io>
 Ryan King <ryan@theryanking.com>
 Paul Sadauskas <psadauskas@gmail.com>
 Shane Becker <veganstraightedge@gmail.com>
+Adam Pohorecki <adam@pohorecki.pl>

--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -172,6 +172,9 @@ module Libhoney
           #   4. flushes the current batch
           #   5. ends the batch_loop
           break
+        rescue Timeout::Error
+          # Timeout::Error happens when there is nothing to pop from the batch_queue.
+          # We rescue it here to avoid spamming the logs with "execution expired" errors.
         rescue Exception => e
           warn "#{self.class.name}: 💥 " + e.message if %w[debug trace].include?(ENV['LOG_LEVEL'])
           warn e.backtrace.join("\n").to_s if ['trace'].include?(ENV['LOG_LEVEL'])


### PR DESCRIPTION
Release 1.19.0 added logging to the exception handler in
`batch_loop`. The problem with this is that under normal circumstances,
you will frequently find that the `batch_queue` is empty, and so
`Timeout.timeout(@send_frequency) { @batch_queue.pop }` will timeout and
raise a `Timeout::Error`. The error is logged every few hundred ms and
makes it practically impossible to work with `honeycomb-beeline` in the
console if you have LOG_LEVEL set to "debug" or "trace".