### PR TITLE
Prepare v1.20.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # libhoney-rb changelog
 
-## changes pending release
+## 1.20.0
+
+### Fixes
+
+- Handle Timeout::Error in TransmissionClient (#95) | [Adam Pohorecki](https://github.com/psyho)
 
 ## 1.19.0
 

--- a/lib/libhoney/version.rb
+++ b/lib/libhoney/version.rb
@@ -1,3 +1,3 @@
 module Libhoney
-  VERSION = '1.19.0'.freeze
+  VERSION = '1.20.0'.freeze
 end


### PR DESCRIPTION
Adds a changelog entry and updates the library version to `v1.20.0`.