### PR TITLE
adds Ruby 3.0 to CI, drops Ruby 2.2 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,10 @@ filters_publish: &filters_publish
 matrix_rubyversions: &matrix_rubyversions
   matrix:
     parameters:
-      rubyversion: ["2.2", "2.3", "2.4", "2.5", "2.6", "2.7"]
+      rubyversion: ["2.3", "2.4", "2.5", "2.6", "2.7", "3.0"]
 
 # Default version of ruby to use for lint and publishing
-default_rubyversion: &default_rubyversion "2.7"
+default_rubyversion: &default_rubyversion "3.0"
 
 executors:
   ruby:
@@ -86,7 +86,8 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            bundle install --jobs=4 --retry=3 --path vendor/bundle
+            bundle config set --local path 'vendor/bundle'
+            bundle install --jobs=4 --retry=3
       - save_cache:
           paths:
             - ./vendor/bundle

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
 
 Style/Documentation:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Ruby gem for sending events to [Honeycomb](https://www.honeycomb.io), a service for debugging your software in production.
 
-Requires Ruby 2.2 or greater.
+Requires Ruby 2.3 or greater.
 
 -   [Usage and Examples](https://docs.honeycomb.io/sdk/ruby/)
 -   [API Reference](https://www.rubydoc.info/gems/libhoney)

--- a/lib/libhoney/client.rb
+++ b/lib/libhoney/client.rb
@@ -81,10 +81,6 @@ module Libhoney
       raise Exception, 'libhoney:  max_concurrent_batches must be greater than 0' if max_concurrent_batches < 1
       raise Exception, 'libhoney:  sample rate must be greater than 0'            if sample_rate < 1
 
-      unless Gem::Dependency.new('ruby', '>= 2.2').match?('ruby', RUBY_VERSION)
-        raise Exception, 'libhoney:  Ruby versions < 2.2 are not supported'
-      end
-
       @builder = Builder.new(self, nil)
 
       @builder.writekey    = writekey

--- a/libhoney.gemspec
+++ b/libhoney.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.2.0'
+  spec.required_ruby_version = '>= 2.3.0'
 
   spec.add_development_dependency 'bump', '~> 0.5'
   spec.add_development_dependency 'bundler'
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'minitest-reporters'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '< 0.69'
+  spec.add_development_dependency 'rubocop', '0.81.0'
   spec.add_development_dependency 'sinatra'
   spec.add_development_dependency 'sinatra-contrib'
   spec.add_development_dependency 'spy', '~> 1.0'


### PR DESCRIPTION
## Which problem is this PR solving?

The absence of testing against latest versions of Ruby in the test suite. The tools used in the test suite do not allow for the same versions of those tools to be used to test the spectrum of Ruby 2.2 through Ruby 3.0. The Ruby core maintainers dropped all support for 2.2 on March 31, 2018.

## Short description of the changes

Adds Ruby 3.0 to the CI matrix and makes the changes necessary for that to succeed:

- Upgrade Rubocop.
  - The version we had pinned to does not work with Ruby 3.0 and was the last version to support Ruby 2.2.
  - Updated to the latest version that supports Ruby 2.3 (note: Ruby core dropped support for this version on March 31, 2019)
- ?? (pending) 

