### PR TITLE
add Ruby runtime info to user agent

### DIFF
--- a/lib/libhoney/experimental_transmission.rb
+++ b/lib/libhoney/experimental_transmission.rb
@@ -101,9 +101,7 @@ module Libhoney
     end
 
     def build_user_agent(user_agent_addition)
-      ua = "libhoney-rb/#{VERSION} (exp-transmission)"
-      ua << " #{user_agent_addition}" if user_agent_addition
-      ua
+      super("(exp-transmission) #{user_agent_addition}".strip)
     end
   end
 end

--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -297,9 +297,10 @@ module Libhoney
     end
 
     def build_user_agent(user_agent_addition)
-      ua = "libhoney-rb/#{VERSION}"
-      ua << " #{user_agent_addition}" if user_agent_addition
-      ua
+      "libhoney-rb/#{VERSION}"
+        .concat(" #{user_agent_addition}")
+        .strip # remove trailing spaces if addition was empty
+        .concat(" Ruby/#{RUBY_VERSION} (#{RUBY_PLATFORM})")
     end
 
     def ensure_threads_running

--- a/test/experimental_transmission_test.rb
+++ b/test/experimental_transmission_test.rb
@@ -68,10 +68,10 @@ class ExperimentalTransmissionClientTest < Minitest::Test
   def test_user_agent_annotation_for_experiment
     transmission = Libhoney::ExperimentalTransmissionClient.new
 
-    assert_equal "libhoney-rb/#{::Libhoney::VERSION} (exp-transmission)",
+    assert_match "libhoney-rb/#{::Libhoney::VERSION} (exp-transmission) Ruby/#{RUBY_VERSION}",
                  transmission.__send__(:build_user_agent, nil)
 
-    assert_equal "libhoney-rb/#{::Libhoney::VERSION} (exp-transmission) awesome_sauce/42.2",
+    assert_match "libhoney-rb/#{::Libhoney::VERSION} (exp-transmission) awesome_sauce/42.2 Ruby/#{RUBY_VERSION}",
                  transmission.__send__(:build_user_agent, 'awesome_sauce/42.2')
   end
 end

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -716,9 +716,12 @@ class LibhoneyUserAgentTest < Minitest::Test
     honey.send_now('ORLY' => 'YA RLY')
     honey.close
 
+    expected_user_agent =
+      "libhoney-rb/#{::Libhoney::VERSION} Ruby/#{RUBY_VERSION} (#{RUBY_PLATFORM})"
+
     assert_requested :post,
                      'https://api.honeycomb.io/1/batch/somedataset',
-                     headers: { 'User-Agent': "libhoney-rb/#{::Libhoney::VERSION}" }
+                     headers: { 'User-Agent': expected_user_agent }
   end
 
   def test_user_agent_addition
@@ -729,7 +732,7 @@ class LibhoneyUserAgentTest < Minitest::Test
 
     assert_requested :post,
                      'https://api.honeycomb.io/1/batch/somedataset',
-                     headers: { 'User-Agent': %r{libhoney-rb/.* test/4.2} }
+                     headers: { 'User-Agent': %r{libhoney-rb/.* test/4.2 Ruby/*.} }
   end
 end
 


### PR DESCRIPTION
## Which problem is this PR solving?

This will help in providing support and debug information for operational environments.

## Short description of the changes

Appends Ruby version information to the outgoing API web request user agent header. I followed [the user agent guidance at MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent) on format.

Examples:
- default:
```
libhoney-rb/1.20.0 Ruby/3.0.0 (x86_64-darwin19)
```
- with a custom user agent `awesome_sauce/42.2` supplied in the config:
```
libhoney-rb/1.20.0 awesome_sauce/42.2 Ruby/3.0.0 (x86_64-darwin19)
```