### PR TITLE
Print hopefully correct units for timing in example

### DIFF
--- a/example/factorial.rb
+++ b/example/factorial.rb
@@ -39,7 +39,7 @@ Thread.new do
       response = libhoney.responses.pop
       break if response.nil?
 
-      puts "Sent: Event with metadata #{response.metadata} in #{response.duration * 1000}ms."
+      puts "Sent: Event with metadata #{response.metadata} in #{response.duration * 1000} seconds."
       puts "Got:  Response code #{response.status_code}"
       puts "      #{response.error.class}: #{response.error}" if response.error
       puts


### PR DESCRIPTION
It looks like (based on the  `* 1000`) that the time to send an event is in _seconds_, not milliseconds.