### PR TITLE
Retry an event batch send once if the connection appears to have been closed by the server due to idleness.

### DIFF
--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -74,7 +74,8 @@ module Libhoney
             'X-Honeycomb-Team' => writekey
           }
 
-          send_with_retry(http, dataset, body, headers, before, batch)
+          response = send_with_retry(http, dataset, body, headers)
+          process_response(response, before, batch)
         rescue Exception => e
           # catch a broader swath of exceptions than is usually good practice,
           # because this is effectively the top-level exception handler for the
@@ -333,8 +334,8 @@ module Libhoney
       end
     end
 
-    def send_with_retry(client, dataset, body, headers, before, batch)
-      response = client.post(
+    def send_with_retry(client, dataset, body, headers)
+      client.post(
         path: "/1/batch/#{Addressable::URI.escape(dataset)}",
         body: body,
         headers: headers
@@ -347,13 +348,11 @@ module Libhoney
       # force excon client close socket
       http.reset
       # next action will open new socket
-      response = client.post(
+      client.post(
         path: "/1/batch/#{Addressable::URI.escape(dataset)}",
         body: body,
         headers: headers
       )
-    ensure
-      process_response(response, before, batch)
     end
   end
 end

--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -352,11 +352,12 @@ module Libhoney
           # retry after resetting the connection.
           # We're not using Excon's idempotent retries because we only
           # want to retry in the specific case of this exception, not
-          # retry all errors.
+          # retry all errors. Setting Excons :retry_errors param did not
+          # succeed in catching this situation.
           client.reset
           retry if attempts < 2
         else
-          raise
+          raise e
         end
       end
     end

--- a/test/transmission_test.rb
+++ b/test/transmission_test.rb
@@ -72,9 +72,7 @@ class TransmissionClientTest < Minitest::Test
     response_queue = SizedQueue.new(10)
     transmission = Libhoney::TransmissionClient.new(responses: response_queue)
     transmission.add(event)
-    sleep(0.5)
 
-    assert_equal(1, response_queue.length)
     response = response_queue.pop
     refute_nil(response, 'There is a response for the event')
     assert_nil(response.error, 'No error on the response')

--- a/test/transmission_test.rb
+++ b/test/transmission_test.rb
@@ -76,8 +76,8 @@ class TransmissionClientTest < Minitest::Test
 
     assert_equal(1, response_queue.length)
     response = response_queue.pop
-    refute_nil(response, 'There is a response for the event.')
-    assert_nil(response.error, 'No error on the response.')
+    refute_nil(response, 'There is a response for the event')
+    assert_nil(response.error, 'No error on the response')
   ensure
     Excon.unstub({ path: '/1/batch/sever_this_connection' })
   end

--- a/test/transmission_test.rb
+++ b/test/transmission_test.rb
@@ -52,13 +52,19 @@ class TransmissionClientTest < Minitest::Test
     transmission.close(drain) # implicit assertion that this does not raise an error and fail the test
   end
 
-  def test_receiving_EOFError_allows_one_retry
+  def test_retry_half_closed_connections
+    attempts = 0
     Excon.defaults[:mock] = true
-    Excon.stub({}, {:body => 'Fallback', :status => 500, :error => Excon::Error::Socket})
+    Excon.stub({ path: '/1/batch/sever_this_connection' }) do
+      attempts += 1
+      raise Excon::Error::Socket, EOFError.new('idle') if attempts <= 1
+
+      { body: '[{ "status": 202 }]', status: 200 }
+    end
 
     mock_builder = Minitest::Mock.new
     mock_builder.expect :writekey, 'write_key'
-    mock_builder.expect :dataset, 'dataset'
+    mock_builder.expect :dataset, 'sever_this_connection'
     mock_builder.expect :sample_rate, 'sample_rate'
     mock_builder.expect :api_host, 'http://localhost:8080'
     event = Libhoney::Event.new(nil, mock_builder)
@@ -67,11 +73,12 @@ class TransmissionClientTest < Minitest::Test
     transmission = Libhoney::TransmissionClient.new(responses: response_queue)
     transmission.add(event)
     sleep(0.5)
-    
+
     assert_equal(1, response_queue.length)
-    e = response_queue.pop
-    refute_nil(e)
-    refute_nil(e.error)
-    puts "An error of type #{e.error} happened"
+    response = response_queue.pop
+    refute_nil(response, 'There is a response for the event.')
+    assert_nil(response.error, 'No error on the response.')
+  ensure
+    Excon.unstub({ path: '/1/batch/sever_this_connection' })
   end
 end


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Honeycomb API servers may closed idle connections after a period of inactivity. Unfortunately, Excon does not try to detect whether a given connection is valid before attempting to perform an operation (eg POST) which leads to Excon throwing an error and subsequent operations that utilise that connection also fail.

This PR introduces a retry mechanism where the libhoney transmission is allowed to retry performing an operation once if it detects a SocketError wrapping an EOFError.

- Fixes #119

## Short description of the changes
- move logic of sending to new `send_with_retry` func
- perform operation and detect SocketError wrapping EOFError and allow one retry
- Adds unit test to ensure libhoney recovers from the error
