### PR TITLE
Add Environment and Services support

### DIFF
--- a/lib/libhoney/client.rb
+++ b/lib/libhoney/client.rb
@@ -281,7 +281,7 @@ module Libhoney
       return dataset if classic_write_key?(write_key)
 
       if dataset.nil? || dataset.empty?
-        warn('found extra whitespace in service name')
+        warn('nil or empty dataset - sending data to \'unknown_dataset\'')
         dataset = DEFAULT_DATASET
       end
       dataset

--- a/lib/libhoney/client.rb
+++ b/lib/libhoney/client.rb
@@ -281,8 +281,13 @@ module Libhoney
       return dataset if classic_write_key?(write_key)
 
       if dataset.nil? || dataset.empty?
-        warn('nil or empty dataset - sending data to \'unknown_dataset\'')
+        warn "nil or empty dataset - sending data to '#{DEFAULT_DATASET}'"
         dataset = DEFAULT_DATASET
+      end
+      trimmed = dataset.strip
+      if dataset != trimmed
+        warn "dataset contained leading or trailing whitespace - sending data '#{trimmed}'"
+        dataset = trimmed
       end
       dataset
     end

--- a/lib/libhoney/client.rb
+++ b/lib/libhoney/client.rb
@@ -286,7 +286,7 @@ module Libhoney
       end
       trimmed = dataset.strip
       if dataset != trimmed
-        warn "dataset contained leading or trailing whitespace - sending data '#{trimmed}'"
+        warn "dataset contained leading or trailing whitespace - sending data to '#{trimmed}'"
         dataset = trimmed
       end
       dataset

--- a/lib/libhoney/client.rb
+++ b/lib/libhoney/client.rb
@@ -280,7 +280,11 @@ module Libhoney
     def get_dataset(dataset, write_key)
       return dataset if classic_write_key?(write_key)
 
-      dataset.nil? || dataset.empty? ? DEFAULT_DATASET : dataset
+      if dataset.nil? || dataset.empty?
+        warn('found extra whitespace in service name')
+        dataset = DEFAULT_DATASET
+      end
+      dataset
     end
 
     def classic_write_key?(write_key)

--- a/lib/libhoney/client.rb
+++ b/lib/libhoney/client.rb
@@ -34,6 +34,7 @@ module Libhoney
     extend Forwardable
 
     API_HOST = 'https://api.honeycomb.io/'.freeze
+    DEFAULT_DATASET = 'unknown_dataset'.freeze
 
     # Instantiates libhoney and prepares it to send events to Honeycomb.
     #
@@ -81,7 +82,7 @@ module Libhoney
       @builder = Builder.new(self, nil)
 
       @builder.writekey    = writekey
-      @builder.dataset     = dataset
+      @builder.dataset     = get_dataset(dataset, writekey)
       @builder.sample_rate = sample_rate
       @builder.api_host    = api_host
 
@@ -274,6 +275,16 @@ module Libhoney
       end
     rescue URI::Error => e
       warn "#{self.class.name}: unable to parse proxy_config. Detail: #{e.class}: #{e.message}"
+    end
+
+    def get_dataset(dataset, write_key)
+      return dataset if classic_write_key?(write_key)
+
+      dataset.nil? || dataset.empty? ? DEFAULT_DATASET : dataset
+    end
+
+    def classic_write_key?(write_key)
+      write_key.nil? || write_key.length == 32
     end
   end
 end

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -52,6 +52,27 @@ class LibhoneyDefaultTest < Minitest::Test
     assert_equal 100, honey.max_concurrent_batches
     assert_equal 1500, honey.pending_work_capacity
   end
+
+  def test_initialize_with_non_classic_writekey_nil_dataset
+    honey = Libhoney::Client.new(writekey: 'd68f9ed1e96432ac1a3380', dataset: nil)
+
+    assert_equal 'd68f9ed1e96432ac1a3380', honey.writekey
+    assert_equal 'unknown_dataset', honey.dataset
+  end
+
+  def test_initialize_with_non_classic_writekey_empty_dataset
+    honey = Libhoney::Client.new(writekey: 'd68f9ed1e96432ac1a3380', dataset: '')
+
+    assert_equal 'd68f9ed1e96432ac1a3380', honey.writekey
+    assert_equal 'unknown_dataset', honey.dataset
+  end
+
+  def test_initialize_with_non_classic_writekey_set_dataset
+    honey = Libhoney::Client.new(writekey: 'd68f9ed1e96432ac1a3380', dataset: 'dataset')
+
+    assert_equal 'd68f9ed1e96432ac1a3380', honey.writekey
+    assert_equal 'dataset', honey.dataset
+  end
 end
 
 class LibhoneyProxyTest < Minitest::Test

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -73,6 +73,13 @@ class LibhoneyDefaultTest < Minitest::Test
     assert_equal 'd68f9ed1e96432ac1a3380', honey.writekey
     assert_equal 'dataset', honey.dataset
   end
+
+  def test_initialize_with_non_classic_writekey_set_dataset_with_whitespace
+    honey = Libhoney::Client.new(writekey: 'd68f9ed1e96432ac1a3380', dataset: '  dataset  ')
+
+    assert_equal 'd68f9ed1e96432ac1a3380', honey.writekey
+    assert_equal 'dataset', honey.dataset
+  end
 end
 
 class LibhoneyProxyTest < Minitest::Test

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -56,6 +56,7 @@ class LibhoneyDefaultTest < Minitest::Test
   def test_initialize_with_non_classic_writekey_nil_dataset
     honey = Libhoney::Client.new(writekey: 'd68f9ed1e96432ac1a3380', dataset: nil)
 
+    assert_match(/dataset/, $stderr.string, 'nil or empty dataset - sending data to \'unknown_dataset\'')
     assert_equal 'd68f9ed1e96432ac1a3380', honey.writekey
     assert_equal 'unknown_dataset', honey.dataset
   end
@@ -63,6 +64,7 @@ class LibhoneyDefaultTest < Minitest::Test
   def test_initialize_with_non_classic_writekey_empty_dataset
     honey = Libhoney::Client.new(writekey: 'd68f9ed1e96432ac1a3380', dataset: '')
 
+    assert_match(/dataset/, $stderr.string, 'nil or empty dataset - sending data to \'unknown_dataset\'')
     assert_equal 'd68f9ed1e96432ac1a3380', honey.writekey
     assert_equal 'unknown_dataset', honey.dataset
   end
@@ -77,6 +79,7 @@ class LibhoneyDefaultTest < Minitest::Test
   def test_initialize_with_non_classic_writekey_and_dataset_with_whitespace
     honey = Libhoney::Client.new(writekey: 'd68f9ed1e96432ac1a3380', dataset: '  dataset  ')
 
+    assert_match(/dataset/, $stderr.string, 'dataset contained leading or trailing whitespace - sending data to \'dataset\'')
     assert_equal 'd68f9ed1e96432ac1a3380', honey.writekey
     assert_equal 'dataset', honey.dataset
   end

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -79,7 +79,11 @@ class LibhoneyDefaultTest < Minitest::Test
   def test_initialize_with_non_classic_writekey_and_dataset_with_whitespace
     honey = Libhoney::Client.new(writekey: 'd68f9ed1e96432ac1a3380', dataset: '  dataset  ')
 
-    assert_match(/dataset/, $stderr.string, 'dataset contained leading or trailing whitespace - sending data to \'dataset\'')
+    assert_match(
+      /dataset/,
+      $stderr.string,
+      'dataset contained leading or trailing whitespace - sending data to \'dataset\''
+    )
     assert_equal 'd68f9ed1e96432ac1a3380', honey.writekey
     assert_equal 'dataset', honey.dataset
   end

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -67,14 +67,14 @@ class LibhoneyDefaultTest < Minitest::Test
     assert_equal 'unknown_dataset', honey.dataset
   end
 
-  def test_initialize_with_non_classic_writekey_set_dataset
+  def test_initialize_with_non_classic_writekey_and_dataset
     honey = Libhoney::Client.new(writekey: 'd68f9ed1e96432ac1a3380', dataset: 'dataset')
 
     assert_equal 'd68f9ed1e96432ac1a3380', honey.writekey
     assert_equal 'dataset', honey.dataset
   end
 
-  def test_initialize_with_non_classic_writekey_set_dataset_with_whitespace
+  def test_initialize_with_non_classic_writekey_and_dataset_with_whitespace
     honey = Libhoney::Client.new(writekey: 'd68f9ed1e96432ac1a3380', dataset: '  dataset  ')
 
     assert_equal 'd68f9ed1e96432ac1a3380', honey.writekey


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
- Closes #122 

## Short description of the changes
- Add default dataset const
- Add func to validate determine dataset, which uses the write_key see if it's a classic key or not
- Warns if nil or empty dataset and sets to `unknown_dataset'
- Warns if dataset contains leading or trialing whitespace, trims whitespace
- Add tests to verify non-classic keys work as expected