### PR TITLE
maint: add ruby 3.1 to CI matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ filters_publish: &filters_publish
 matrix_rubyversions: &matrix_rubyversions
   matrix:
     parameters:
-      rubyversion: ["2.4", "2.5", "2.6", "2.7", "3.0"]
+      rubyversion: ["2.4", "2.5", "2.6", "2.7", "3.0", "3.1"]
 
 # Default version of ruby to use for lint and publishing
 default_rubyversion: &default_rubyversion "3.0"


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- ruby 3.1 was released in December 💎

## Short description of the changes

- add 3.1 to CI test matrix

