### PR TITLE
feat: support classic-flavored ingest keys

### DIFF
--- a/lib/libhoney.rb
+++ b/lib/libhoney.rb
@@ -8,13 +8,15 @@ require 'libhoney/response'
 require 'libhoney/transmission'
 
 module Libhoney
+  CLASSIC_ORIGINAL_FLAVOR = Regexp.new(/\A[[:alnum:]]{32}\z/)
+  CLASSIC_V3_INGEST = Regexp.new(/\Ahc[a-z]ic_[[:alnum:]]{58}\z/)
   # Determines if the given string is a Honeycomb API key for Classic environments.
   #
   # @param api_key [String] the string to check
   # @return [Boolean] true if the string is nil or a classic API key, false otherwise
   def self.classic_api_key?(api_key)
-    api_key.nil? ||
-      api_key.match(/\A[[:alnum:]]{32}\z/) ||
-      api_key.match(/\Ahc[a-z]ic_[[:alnum:]]{58}\z/)
+    api_key.nil? || # default to classic behavior if no API key is provided
+      CLASSIC_ORIGINAL_FLAVOR.match?(api_key) ||
+      CLASSIC_V3_INGEST.match?(api_key)
   end
 end

--- a/lib/libhoney.rb
+++ b/lib/libhoney.rb
@@ -8,9 +8,13 @@ require 'libhoney/response'
 require 'libhoney/transmission'
 
 module Libhoney
-  def self.classic_write_key?(write_key)
-    write_key.nil? ||
-      write_key.match(/\A[[:alnum:]]{32}\z/) ||
-      write_key.match(/\Ahc[a-z]ic_[[:alnum:]]{58}\z/)
+  # Determines if the given string is a Honeycomb API key for Classic environments.
+  #
+  # @param api_key [String] the string to check
+  # @return [Boolean] true if the string is nil or a classic API key, false otherwise
+  def self.classic_api_key?(api_key)
+    api_key.nil? ||
+      api_key.match(/\A[[:alnum:]]{32}\z/) ||
+      api_key.match(/\Ahc[a-z]ic_[[:alnum:]]{58}\z/)
   end
 end

--- a/lib/libhoney.rb
+++ b/lib/libhoney.rb
@@ -6,3 +6,11 @@ require 'libhoney/version'
 require 'libhoney/builder'
 require 'libhoney/response'
 require 'libhoney/transmission'
+
+module Libhoney
+  def self.classic_write_key?(write_key)
+    write_key.nil? ||
+      write_key.length == 32 ||
+      write_key =~ /^hc[a-z]ic_[[:alnum:]]{58}$/
+  end
+end

--- a/lib/libhoney.rb
+++ b/lib/libhoney.rb
@@ -8,15 +8,23 @@ require 'libhoney/response'
 require 'libhoney/transmission'
 
 module Libhoney
-  CLASSIC_ORIGINAL_FLAVOR = Regexp.new(/\A[[:alnum:]]{32}\z/)
-  CLASSIC_V3_INGEST = Regexp.new(/\Ahc[a-z]ic_[[:alnum:]]{58}\z/)
   # Determines if the given string is a Honeycomb API key for Classic environments.
   #
   # @param api_key [String] the string to check
   # @return [Boolean] true if the string is nil or a classic API key, false otherwise
   def self.classic_api_key?(api_key)
     api_key.nil? || # default to classic behavior if no API key is provided
-      CLASSIC_ORIGINAL_FLAVOR.match?(api_key) ||
-      CLASSIC_V3_INGEST.match?(api_key)
+      CLASSIC_KEY_ORIGINAL_FLAVOR.match?(api_key) ||
+      CLASSIC_KEY_V3_INGEST.match?(api_key)
   end
+
+  # Private constant for key format detection.
+  # @api private
+  CLASSIC_KEY_ORIGINAL_FLAVOR = Regexp.new(/\A[[:alnum:]]{32}\z/)
+  private_constant :CLASSIC_KEY_ORIGINAL_FLAVOR
+
+  # Private constant for key format detection.
+  # @api private
+  CLASSIC_KEY_V3_INGEST = Regexp.new(/\Ahc[a-z]ic_[[:alnum:]]{58}\z/)
+  private_constant :CLASSIC_KEY_V3_INGEST
 end

--- a/lib/libhoney.rb
+++ b/lib/libhoney.rb
@@ -10,7 +10,7 @@ require 'libhoney/transmission'
 module Libhoney
   def self.classic_write_key?(write_key)
     write_key.nil? ||
-      write_key.length == 32 ||
-      write_key =~ /^hc[a-z]ic_[[:alnum:]]{58}$/
+      write_key.match(/\A[[:alnum:]]{32}\z/) ||
+      write_key.match(/\Ahc[a-z]ic_[[:alnum:]]{58}\z/)
   end
 end

--- a/lib/libhoney/client.rb
+++ b/lib/libhoney/client.rb
@@ -203,11 +203,11 @@ module Libhoney
       rand(1..sample_rate) != 1
     end
 
+    private
+
     def classic_write_key?(write_key)
       Libhoney.classic_write_key?(write_key)
     end
-
-    private
 
     ##
     # Parameters to pass to a transmission based on client config.

--- a/lib/libhoney/client.rb
+++ b/lib/libhoney/client.rb
@@ -293,7 +293,9 @@ module Libhoney
     end
 
     def classic_write_key?(write_key)
-      write_key.nil? || write_key.length == 32
+      write_key.nil? ||
+        write_key.length == 32 ||
+        write_key =~ /^hc[a-z]ic_[[:alnum:]]{58}$/
     end
   end
 end

--- a/lib/libhoney/client.rb
+++ b/lib/libhoney/client.rb
@@ -205,10 +205,6 @@ module Libhoney
 
     private
 
-    def classic_write_key?(write_key)
-      Libhoney.classic_api_key?(write_key)
-    end
-
     ##
     # Parameters to pass to a transmission based on client config.
     #
@@ -294,6 +290,10 @@ module Libhoney
         dataset = trimmed
       end
       dataset
+    end
+
+    def classic_write_key?(write_key)
+      Libhoney.classic_api_key?(write_key)
     end
   end
 end

--- a/lib/libhoney/client.rb
+++ b/lib/libhoney/client.rb
@@ -204,9 +204,7 @@ module Libhoney
     end
 
     def classic_write_key?(write_key)
-      write_key.nil? ||
-        write_key.length == 32 ||
-        write_key =~ /^hc[a-z]ic_[[:alnum:]]{58}$/
+      Libhoney.classic_write_key?(write_key)
     end
 
     private

--- a/lib/libhoney/client.rb
+++ b/lib/libhoney/client.rb
@@ -206,7 +206,7 @@ module Libhoney
     private
 
     def classic_write_key?(write_key)
-      Libhoney.classic_write_key?(write_key)
+      Libhoney.classic_api_key?(write_key)
     end
 
     ##

--- a/lib/libhoney/client.rb
+++ b/lib/libhoney/client.rb
@@ -278,7 +278,7 @@ module Libhoney
     end
 
     def get_dataset(dataset, write_key)
-      return dataset if classic_write_key?(write_key)
+      return dataset if classic_api_key?(write_key)
 
       if dataset.nil? || dataset.empty?
         warn "nil or empty dataset - sending data to '#{DEFAULT_DATASET}'"
@@ -292,7 +292,8 @@ module Libhoney
       dataset
     end
 
-    def classic_write_key?(write_key)
+    # @api private
+    def classic_api_key?(write_key)
       Libhoney.classic_api_key?(write_key)
     end
   end

--- a/lib/libhoney/client.rb
+++ b/lib/libhoney/client.rb
@@ -203,6 +203,12 @@ module Libhoney
       rand(1..sample_rate) != 1
     end
 
+    def classic_write_key?(write_key)
+      write_key.nil? ||
+        write_key.length == 32 ||
+        write_key =~ /^hc[a-z]ic_[[:alnum:]]{58}$/
+    end
+
     private
 
     ##
@@ -290,12 +296,6 @@ module Libhoney
         dataset = trimmed
       end
       dataset
-    end
-
-    def classic_write_key?(write_key)
-      write_key.nil? ||
-        write_key.length == 32 ||
-        write_key =~ /^hc[a-z]ic_[[:alnum:]]{58}$/
     end
   end
 end

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -110,28 +110,28 @@ class LibhoneyKeyChecking < Minitest::Test
   def test_classic_key_32_chars
     #                       1         2         3
     classic_key = '12345678901234567890123456789012'
-    assert Libhoney.classic_write_key? classic_key
+    assert Libhoney.classic_api_key? classic_key
     assert @honey.send("classic_write_key?", classic_key)
   end
 
   def test_classic_key_v3_ingest
     #                                       1         2         3         4         5
     classic_v3_ingest_key = 'hcaic_1234567890123456789012345678901234567890123456789012345678'
-    assert Libhoney.classic_write_key? classic_v3_ingest_key
+    assert Libhoney.classic_api_key? classic_v3_ingest_key
     assert @honey.send("classic_write_key?", classic_v3_ingest_key)
   end
 
   def test_not_classic_key
     #                  1         2
     og_key = '1234567890123456789012'
-    refute Libhoney.classic_write_key? og_key
+    refute Libhoney.classic_api_key? og_key
     refute @honey.send("classic_write_key?", og_key)
   end
 
   def test_not_classic_key_v3_ingest
     #                               1         2         3         4         5
     v3_ingest_key = 'hcaik_1234567890123456789012345678901234567890123456789012345678'
-    refute Libhoney.classic_write_key? v3_ingest_key
+    refute Libhoney.classic_api_key? v3_ingest_key
     refute @honey.send("classic_write_key?", v3_ingest_key)
   end
 
@@ -139,7 +139,7 @@ class LibhoneyKeyChecking < Minitest::Test
     #                           1         2
     v3_key_id = 'hcxik_12345678901234567890123456'
     failure_message = 'Despite a v3 key ID being 32 characters, it is not a classic key.'
-    refute Libhoney.classic_write_key?(v3_key_id), failure_message
+    refute Libhoney.classic_api_key?(v3_key_id), failure_message
     refute @honey.send("classic_write_key?", v3_key_id), failure_message
   end
 end

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -107,19 +107,27 @@ class LibhoneyKeyChecking < Minitest::Test
   end
 
   def test_classic_key_32_chars
-    assert @honey.classic_write_key? SecureRandom.alphanumeric(32)
+    classic_key = SecureRandom.alphanumeric(32)
+    assert Libhoney.classic_write_key? classic_key
+    assert @honey.classic_write_key? classic_key
   end
 
   def test_classic_key_v3_ingest
-    assert @honey.classic_write_key? "hcaic_#{SecureRandom.alphanumeric(58)}"
+    classic_v3_ingest_key = "hcaic_#{SecureRandom.alphanumeric(58)}"
+    assert Libhoney.classic_write_key? classic_v3_ingest_key
+    assert @honey.classic_write_key? classic_v3_ingest_key
   end
 
   def test_not_classic_key
-    refute @honey.classic_write_key? SecureRandom.alphanumeric(22)
+    og_key = SecureRandom.alphanumeric(22)
+    refute Libhoney.classic_write_key? og_key
+    refute @honey.classic_write_key? og_key
   end
 
   def test_not_classic_key_v3_ingest
-    refute @honey.classic_write_key? "hcaik_#{SecureRandom.alphanumeric(58)}"
+    v3_ingest_key = "hcaik_#{SecureRandom.alphanumeric(58)}"
+    refute Libhoney.classic_write_key? v3_ingest_key
+    refute @honey.classic_write_key? v3_ingest_key
   end
 end
 

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -109,35 +109,35 @@ class LibhoneyKeyChecking < Minitest::Test
 
   def test_classic_when_no_api_key_provided
     assert Libhoney.classic_api_key?(nil)
-    assert @honey.send('classic_write_key?', nil)
+    assert @honey.send('classic_api_key?', nil)
   end
 
   def test_classic_key_32_chars
     #                          1         2         3
     classic_og_key = '12345678901234567890123456789012'
     assert Libhoney.classic_api_key? classic_og_key
-    assert @honey.send('classic_write_key?', classic_og_key)
+    assert @honey.send('classic_api_key?', classic_og_key)
   end
 
   def test_classic_key_v3_ingest
     #                                       1         2         3         4         5
     classic_v3_ingest_key = 'hcaic_1234567890123456789012345678901234567890123456789012345678'
     assert Libhoney.classic_api_key? classic_v3_ingest_key
-    assert @honey.send('classic_write_key?', classic_v3_ingest_key)
+    assert @honey.send('classic_api_key?', classic_v3_ingest_key)
   end
 
   def test_not_classic_key
     #                     1         2
     e_n_s_key = '1234567890123456789012'
     refute Libhoney.classic_api_key? e_n_s_key
-    refute @honey.send('classic_write_key?', e_n_s_key)
+    refute @honey.send('classic_api_key?', e_n_s_key)
   end
 
   def test_not_classic_key_v3_ingest
     #                               1         2         3         4         5
     v3_ingest_key = 'hcaik_1234567890123456789012345678901234567890123456789012345678'
     refute Libhoney.classic_api_key? v3_ingest_key
-    refute @honey.send('classic_write_key?', v3_ingest_key)
+    refute @honey.send('classic_api_key?', v3_ingest_key)
   end
 
   def test_not_classic_key_v3_key_id_only
@@ -145,7 +145,7 @@ class LibhoneyKeyChecking < Minitest::Test
     v3_key_id = 'hcxik_12345678901234567890123456'
     failure_message = 'Despite a v3 key ID being 32 characters, it is not a classic key.'
     refute Libhoney.classic_api_key?(v3_key_id), failure_message
-    refute @honey.send('classic_write_key?', v3_key_id), failure_message
+    refute @honey.send('classic_api_key?', v3_key_id), failure_message
   end
 end
 

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -109,35 +109,35 @@ class LibhoneyKeyChecking < Minitest::Test
 
   def test_classic_when_no_api_key_provided
     assert Libhoney.classic_api_key?(nil)
-    assert @honey.send("classic_write_key?", nil)
+    assert @honey.send('classic_write_key?', nil)
   end
 
   def test_classic_key_32_chars
     #                       1         2         3
     classic_key = '12345678901234567890123456789012'
     assert Libhoney.classic_api_key? classic_key
-    assert @honey.send("classic_write_key?", classic_key)
+    assert @honey.send('classic_write_key?', classic_key)
   end
 
   def test_classic_key_v3_ingest
     #                                       1         2         3         4         5
     classic_v3_ingest_key = 'hcaic_1234567890123456789012345678901234567890123456789012345678'
     assert Libhoney.classic_api_key? classic_v3_ingest_key
-    assert @honey.send("classic_write_key?", classic_v3_ingest_key)
+    assert @honey.send('classic_write_key?', classic_v3_ingest_key)
   end
 
   def test_not_classic_key
     #                  1         2
     og_key = '1234567890123456789012'
     refute Libhoney.classic_api_key? og_key
-    refute @honey.send("classic_write_key?", og_key)
+    refute @honey.send('classic_write_key?', og_key)
   end
 
   def test_not_classic_key_v3_ingest
     #                               1         2         3         4         5
     v3_ingest_key = 'hcaik_1234567890123456789012345678901234567890123456789012345678'
     refute Libhoney.classic_api_key? v3_ingest_key
-    refute @honey.send("classic_write_key?", v3_ingest_key)
+    refute @honey.send('classic_write_key?', v3_ingest_key)
   end
 
   def test_not_classic_key_v3_key_id_only
@@ -145,7 +145,7 @@ class LibhoneyKeyChecking < Minitest::Test
     v3_key_id = 'hcxik_12345678901234567890123456'
     failure_message = 'Despite a v3 key ID being 32 characters, it is not a classic key.'
     refute Libhoney.classic_api_key?(v3_key_id), failure_message
-    refute @honey.send("classic_write_key?", v3_key_id), failure_message
+    refute @honey.send('classic_write_key?', v3_key_id), failure_message
   end
 end
 

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -107,6 +107,11 @@ class LibhoneyKeyChecking < Minitest::Test
     @honey = Libhoney::Client.new(writekey: "We don't care about this one.", dataset: 'whatevs')
   end
 
+  def test_classic_when_no_api_key_provided
+    assert Libhoney.classic_api_key?(nil)
+    assert @honey.send("classic_write_key?", nil)
+  end
+
   def test_classic_key_32_chars
     #                       1         2         3
     classic_key = '12345678901234567890123456789012'

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -111,28 +111,28 @@ class LibhoneyKeyChecking < Minitest::Test
     #                       1         2         3
     classic_key = '12345678901234567890123456789012'
     assert Libhoney.classic_write_key? classic_key
-    assert @honey.classic_write_key? classic_key
+    assert @honey.send("classic_write_key?", classic_key)
   end
 
   def test_classic_key_v3_ingest
     #                                       1         2         3         4         5
     classic_v3_ingest_key = 'hcaic_1234567890123456789012345678901234567890123456789012345678'
     assert Libhoney.classic_write_key? classic_v3_ingest_key
-    assert @honey.classic_write_key? classic_v3_ingest_key
+    assert @honey.send("classic_write_key?", classic_v3_ingest_key)
   end
 
   def test_not_classic_key
     #                  1         2
     og_key = '1234567890123456789012'
     refute Libhoney.classic_write_key? og_key
-    refute @honey.classic_write_key? og_key
+    refute @honey.send("classic_write_key?", og_key)
   end
 
   def test_not_classic_key_v3_ingest
     #                               1         2         3         4         5
     v3_ingest_key = 'hcaik_1234567890123456789012345678901234567890123456789012345678'
     refute Libhoney.classic_write_key? v3_ingest_key
-    refute @honey.classic_write_key? v3_ingest_key
+    refute @honey.send("classic_write_key?", v3_ingest_key)
   end
 
   def test_not_classic_key_v3_key_id_only
@@ -140,7 +140,7 @@ class LibhoneyKeyChecking < Minitest::Test
     v3_key_id = 'hcxik_12345678901234567890123456'
     failure_message = 'Despite a v3 key ID being 32 characters, it is not a classic key.'
     refute Libhoney.classic_write_key?(v3_key_id), failure_message
-    refute @honey.classic_write_key?(v3_key_id), failure_message
+    refute @honey.send("classic_write_key?", v3_key_id), failure_message
   end
 end
 

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -54,7 +54,8 @@ class LibhoneyDefaultTest < Minitest::Test
   end
 
   def test_initialize_with_classic_v3_ingestkey_and_dataset
-    classic_v3_ingest_key = "hcaic_#{SecureRandom.alphanumeric(58)}"
+    #                                       1         2         3         4         5
+    classic_v3_ingest_key = 'hcaic_1234567890123456789012345678901234567890123456789012345678'
     honey = Libhoney::Client.new(
       writekey: classic_v3_ingest_key,
       dataset: 'an dataset'
@@ -107,25 +108,29 @@ class LibhoneyKeyChecking < Minitest::Test
   end
 
   def test_classic_key_32_chars
-    classic_key = SecureRandom.alphanumeric(32)
+    #                       1         2         3
+    classic_key = '12345678901234567890123456789012'
     assert Libhoney.classic_write_key? classic_key
     assert @honey.classic_write_key? classic_key
   end
 
   def test_classic_key_v3_ingest
-    classic_v3_ingest_key = "hcaic_#{SecureRandom.alphanumeric(58)}"
+    #                                       1         2         3         4         5
+    classic_v3_ingest_key = 'hcaic_1234567890123456789012345678901234567890123456789012345678'
     assert Libhoney.classic_write_key? classic_v3_ingest_key
     assert @honey.classic_write_key? classic_v3_ingest_key
   end
 
   def test_not_classic_key
-    og_key = SecureRandom.alphanumeric(22)
+    #                  1         2
+    og_key = '1234567890123456789012'
     refute Libhoney.classic_write_key? og_key
     refute @honey.classic_write_key? og_key
   end
 
   def test_not_classic_key_v3_ingest
-    v3_ingest_key = "hcaik_#{SecureRandom.alphanumeric(58)}"
+    #                               1         2         3         4         5
+    v3_ingest_key = 'hcaik_1234567890123456789012345678901234567890123456789012345678'
     refute Libhoney.classic_write_key? v3_ingest_key
     refute @honey.classic_write_key? v3_ingest_key
   end

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -134,6 +134,14 @@ class LibhoneyKeyChecking < Minitest::Test
     refute Libhoney.classic_write_key? v3_ingest_key
     refute @honey.classic_write_key? v3_ingest_key
   end
+
+  def test_not_classic_key_v3_key_id_only
+    #                           1         2
+    v3_key_id = 'hcxik_12345678901234567890123456'
+    failure_message = 'Despite a v3 key ID being 32 characters, it is not a classic key.'
+    refute Libhoney.classic_write_key?(v3_key_id), failure_message
+    refute @honey.classic_write_key?(v3_key_id), failure_message
+  end
 end
 
 class LibhoneyProxyTest < Minitest::Test

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -113,10 +113,10 @@ class LibhoneyKeyChecking < Minitest::Test
   end
 
   def test_classic_key_32_chars
-    #                       1         2         3
-    classic_key = '12345678901234567890123456789012'
-    assert Libhoney.classic_api_key? classic_key
-    assert @honey.send('classic_write_key?', classic_key)
+    #                          1         2         3
+    classic_og_key = '12345678901234567890123456789012'
+    assert Libhoney.classic_api_key? classic_og_key
+    assert @honey.send('classic_write_key?', classic_og_key)
   end
 
   def test_classic_key_v3_ingest
@@ -127,10 +127,10 @@ class LibhoneyKeyChecking < Minitest::Test
   end
 
   def test_not_classic_key
-    #                  1         2
-    og_key = '1234567890123456789012'
-    refute Libhoney.classic_api_key? og_key
-    refute @honey.send('classic_write_key?', og_key)
+    #                     1         2
+    e_n_s_key = '1234567890123456789012'
+    refute Libhoney.classic_api_key? e_n_s_key
+    refute @honey.send('classic_write_key?', e_n_s_key)
   end
 
   def test_not_classic_key_v3_ingest

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -53,6 +53,17 @@ class LibhoneyDefaultTest < Minitest::Test
     assert_equal 1500, honey.pending_work_capacity
   end
 
+  def test_initialize_with_classic_v3_ingestkey_and_dataset
+    classic_v3_ingest_key = "hcaic_#{SecureRandom.alphanumeric(58)}"
+    honey = Libhoney::Client.new(
+      writekey: classic_v3_ingest_key,
+      dataset: 'an dataset'
+    )
+
+    assert_equal classic_v3_ingest_key, honey.writekey
+    assert_equal 'an dataset', honey.dataset
+  end
+
   def test_initialize_with_non_classic_writekey_nil_dataset
     honey = Libhoney::Client.new(writekey: 'd68f9ed1e96432ac1a3380', dataset: nil)
 
@@ -86,6 +97,29 @@ class LibhoneyDefaultTest < Minitest::Test
     )
     assert_equal 'd68f9ed1e96432ac1a3380', honey.writekey
     assert_equal 'dataset', honey.dataset
+  end
+end
+
+class LibhoneyKeyChecking < Minitest::Test
+  def setup
+    # set a bogus key to quiet warnings during initialization
+    @honey = Libhoney::Client.new(writekey: "We don't care about this one.", dataset: 'whatevs')
+  end
+
+  def test_classic_key_32_chars
+    assert @honey.send('classic_write_key?', SecureRandom.alphanumeric(32))
+  end
+
+  def test_classic_key_v3_ingest
+    assert @honey.send('classic_write_key?', "hcaic_#{SecureRandom.alphanumeric(58)}")
+  end
+
+  def test_not_classic_key
+    refute @honey.send('classic_write_key?', SecureRandom.alphanumeric(22))
+  end
+
+  def test_not_classic_key_v3_ingest
+    refute @honey.send('classic_write_key?', "hcaik_#{SecureRandom.alphanumeric(58)}")
   end
 end
 

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -107,19 +107,19 @@ class LibhoneyKeyChecking < Minitest::Test
   end
 
   def test_classic_key_32_chars
-    assert @honey.send('classic_write_key?', SecureRandom.alphanumeric(32))
+    assert @honey.classic_write_key? SecureRandom.alphanumeric(32)
   end
 
   def test_classic_key_v3_ingest
-    assert @honey.send('classic_write_key?', "hcaic_#{SecureRandom.alphanumeric(58)}")
+    assert @honey.classic_write_key? "hcaic_#{SecureRandom.alphanumeric(58)}"
   end
 
   def test_not_classic_key
-    refute @honey.send('classic_write_key?', SecureRandom.alphanumeric(22))
+    refute @honey.classic_write_key? SecureRandom.alphanumeric(22)
   end
 
   def test_not_classic_key_v3_ingest
-    refute @honey.send('classic_write_key?', "hcaik_#{SecureRandom.alphanumeric(58)}")
+    refute @honey.classic_write_key? "hcaik_#{SecureRandom.alphanumeric(58)}"
   end
 end
 


### PR DESCRIPTION
## Which problem is this PR solving?

There's a new key format on the block: ingest keys. To determine the correct dataset defaults for classic environments, the key detection logic needs an update. So that the details of the logic are implemented in fewer places, expose the logic as public methods, primarily for Beeline use. 

## Short description of the changes

- update classic key detection logic
- promote `Libhoney::Client.classic_write_key?` to public instance method
- also provide same logic as a module-level method `Libhoney.classic_write_key?` so the check can be made without an instance of the client

## To Consider

- Is the dated "write_key" vocabulary something we want to keep as this method goes public? Maybe provide aliased `classic_api_key?` methods as well?
