### PR TITLE
fix: omit events generated by the transmission of events

### DIFF
--- a/lib/libhoney/event.rb
+++ b/lib/libhoney/event.rb
@@ -121,7 +121,12 @@ module Libhoney
     #
     # @return [self] this event.
     def send_presampled
-      @libhoney.send_event(self)
+      if Thread.current[:libhoney_transmitting]
+        @libhoney.send_dropped_response(self, 'dropped event generated during transmission')
+      else
+        @libhoney.send_event(self)
+      end
+
       self
     end
   end

--- a/lib/libhoney/log_transmission.rb
+++ b/lib/libhoney/log_transmission.rb
@@ -19,6 +19,7 @@ module Libhoney
 
     # Prints an event
     def add(event)
+      Thread.current[:libhoney_transmitting] = true
       if @verbose
         metadata = "Honeycomb dataset '#{event.dataset}' | #{event.timestamp.iso8601}"
         metadata << " (sample rate: #{event.sample_rate})" if event.sample_rate != 1
@@ -27,6 +28,8 @@ module Libhoney
       clean_data(event.data).tap do |data|
         @output.puts(data.to_json)
       end
+    ensure
+      Thread.current[:libhoney_transmitting] = false
     end
 
     # Flushes the output (but does not close it)

--- a/lib/libhoney/mock_transmission.rb
+++ b/lib/libhoney/mock_transmission.rb
@@ -16,7 +16,10 @@ module Libhoney
 
     # Records an event
     def add(event)
+      Thread.current[:libhoney_transmitting] = true
       @events.push(event)
+    ensure
+      Thread.current[:libhoney_transmitting] = false
     end
 
     # Does nothing.

--- a/lib/libhoney/transmission.rb
+++ b/lib/libhoney/transmission.rb
@@ -53,7 +53,8 @@ module Libhoney
       ensure_threads_running
     end
 
-    def send_loop
+    def send_loop # rubocop:disable Metrics/AbcSize
+      Thread.current[:libhoney_transmitting] = true
       http_clients = build_http_clients
 
       # eat events until we run out
@@ -106,6 +107,7 @@ module Libhoney
           nil
         end
       end
+      Thread.current[:libhoney_transmitting] = false
     end
 
     def close(drain)

--- a/test/libhoney_test.rb
+++ b/test/libhoney_test.rb
@@ -638,6 +638,124 @@ class LibhoneyTest < Minitest::Test
 
     assert_requested :post, 'https://api.honeycomb.io/1/batch/mydataset%20send'
   end
+
+  class ValueWithEventDuringTransmission
+    def initialize(libhoney)
+      @libhoney = libhoney
+    end
+
+    # to_s gets called by Libhoney::Cleaner on field values during
+    # transmission, so if an instance of this class is assigned to a field on
+    # an outer event, the inner event will be generated from within the
+    # send_loop thread
+    def to_s
+      event.send
+      'value'
+    end
+
+    def event
+      event = @libhoney.event
+      event.metadata = 'inner'
+      event
+    end
+  end
+
+  def test_event_during_transmission
+    stub_request(:post, 'https://api.honeycomb.io/1/batch/mydataset').to_rack(StubHoneycombServer)
+
+    event = @honey.event
+    event.metadata = 'outer'
+    event.add_field('field', ValueWithEventDuringTransmission.new(@honey))
+    event.send
+
+    # We can't rely on @honey.close to flush both events here. At first, only the outer event is in
+    # the batch_queue. Once we call @honey.close, the outer event is flushed to the send_queue, and
+    # the batch_loop exits. But then the inner event is triggered on the send_loop after we pop the
+    # outer event off the send_queue. If we didn't prevent it, libhoney would proceed to push the
+    # inner event to the batch_queue and start the batch_loop up all over again, along with more
+    # send_loop threads. That effectively undoes the @honey.close and seems to lead to other
+    # threading errors that are hard to grok: sometimes deadlocks, sometimes hanging indefinitely,
+    # sometimes a different thread does the POST to Honeycomb but it's unstubbed on that thread...
+    #
+    # So instead of all that, wait a little bit for both events to get processed organically by the
+    # existing batch_loop thread. It shouldn't take long.
+    responses = []
+    begin
+      Timeout.timeout(1) do
+        while (response = @honey.responses.pop)
+          responses << response
+        end
+      end
+    rescue Timeout::Error
+      if responses.count < 2
+        flunk "waited for libhoney to process 2 events, got #{responses.count} (try increasing timeout?)"
+      elsif responses.count > 2
+        flunk "expected only 2 events to be processed, got #{responses.count}: #{responses.inspect}"
+      else
+        @honey.close # should now be able to safely close, since we got through both of the events
+      end
+    end
+
+    # the order of these responses changes before & after the associated fix,
+    # so keeping this loose to run the test on both the old and new versions
+    outer = responses.find { |response| response.metadata == 'outer' }
+    inner = responses.find { |response| response.metadata == 'inner' }
+
+    refute_nil outer, 'could not find response for outer event'
+    refute_nil inner, 'could not find response for inner event'
+
+    assert_nil outer.error, 'outer event should have succeeded'
+    refute_nil inner.error, 'inner event should have been dropped'
+  end
+
+  class ValueWithInfiniteEventsDuringTransmission < ValueWithEventDuringTransmission
+    def event
+      event = super
+      event.add_field('self', self) # self.to_s triggers yet another event when *this* event gets sent
+      event
+    end
+  end
+
+  def test_infinite_events_during_transmission
+    stub_request(:post, 'https://api.honeycomb.io/1/batch/mydataset').to_rack(StubHoneycombServer)
+
+    event = @honey.event
+    event.metadata = 'outer'
+    event.add_field('field', ValueWithInfiniteEventsDuringTransmission.new(@honey))
+    event.send
+
+    # Similar to test_event_during_transmission, we can't rely on @honey.close here. Furthermore,
+    # the failure mode here results in an infinite loop anyway, so we just want to do this "wait for
+    # a bit, then look at the results" pattern regardless.
+    #
+    # We still expect 2 responses, assuming the inner event that would have triggered the infinite
+    # loop gets booted out as an error response.
+    responses = []
+    begin
+      Timeout.timeout(1) do
+        while (response = @honey.responses.pop)
+          responses << response
+        end
+      end
+    rescue Timeout::Error
+      if responses.count > 2
+        flunk "gave up after processing #{responses.count} events, probably reproduced an infinite loop bug"
+      elsif responses.count < 2
+        flunk "expected 2 events to be generated, got #{responses.count} (try increasing timeout?)"
+      else
+        @honey.close # should now be able to safely close, since we got both responses
+      end
+    end
+
+    outer = responses.find { |response| response.metadata == 'outer' }
+    inner = responses.find { |response| response.metadata == 'inner' }
+
+    refute_nil outer, 'could not find response for outer event'
+    refute_nil inner, 'could not find response for inner event'
+
+    assert_nil outer.error, 'outer event should have succeeded'
+    refute_nil inner.error, 'inner event should have been dropped'
+  end
 end
 
 class LibhoneyTransmissionConfigTest < Minitest::Test

--- a/test/log_test.rb
+++ b/test/log_test.rb
@@ -1,0 +1,56 @@
+require 'test_helper'
+require 'stringio'
+require 'libhoney'
+
+class LibhoneyLogClientTest < Minitest::Test
+  def setup
+    @output = StringIO.new
+    @libhoney = Libhoney::LogClient.new(output: @output)
+  end
+
+  class ValueWithEventDuringTransmission
+    def initialize(libhoney)
+      @libhoney = libhoney
+    end
+
+    # to_s gets called by Libhoney::Cleaner on field values synchronously before logging, so if an
+    # instance of this class is assigned to a field on an outer event, the inner event will be
+    # generated from within the Libhoney::LogTransmissionClient
+    def to_s
+      event.send
+      'value'
+    end
+
+    def event
+      event = @libhoney.event
+      event.add_field('name', 'inner')
+      event
+    end
+  end
+
+  def test_event_during_transmission
+    event = @libhoney.event
+    event.add_field('name', 'outer')
+    event.add_field('field', ValueWithEventDuringTransmission.new(@libhoney))
+    event.send
+    @libhoney.close
+    assert_equal('{"name":"outer","field":"value"}', @output.string.strip)
+  end
+
+  class ValueWithInfiniteEventsDuringTransmission < ValueWithEventDuringTransmission
+    def event
+      event = super
+      event.add_field('self', self) # self.to_s triggers yet another event when *this* event gets sent
+      event
+    end
+  end
+
+  def test_infinite_events_during_transmission
+    event = @libhoney.event
+    event.add_field('name', 'outer')
+    event.add_field('field', ValueWithInfiniteEventsDuringTransmission.new(@libhoney))
+    event.send # SystemStackError is raised here unless events are prevented during transmission
+    @libhoney.close
+    assert_equal('{"name":"outer","field":"value"}', @output.string.strip)
+  end
+end

--- a/test/test_test.rb
+++ b/test/test_test.rb
@@ -13,4 +13,31 @@ class LibhoneyTestTest < Minitest::Test
     event = fakehoney.events[0]
     assert_equal 'bargle', event.data['argle']
   end
+
+  # We could imagine a pathological case where Array#push is monkey-patched to generate
+  # libhoney events. This would probably break lots of other things, but since the
+  # implementation of the MockTransmissionClient#add simply pushes the incoming event onto
+  # an array, it may also generate an infinite loop unless we avoid sending the events
+  # generated during transmission. So, it seems worth the minor effort.
+  def test_events_during_transmission
+    libhoney = Libhoney::TestClient.new
+
+    count = 0
+    push = lambda do |event|
+      count += 1
+      assert_equal 'outer', event.metadata, 'inner events should not be pushed'
+      assert_equal 1, count, 'attempted to push multiple outer events'
+      inner_event = libhoney.event
+      inner_event.metadata = 'inner'
+      inner_event.send
+    end
+
+    libhoney.events.stub(:push, push) do
+      outer_event = libhoney.event
+      outer_event.metadata = 'outer'
+      outer_event.send
+    end
+
+    assert_equal 1, count, 'outer event did not get pushed'
+  end
 end


### PR DESCRIPTION
## Summary

Adds a thread-local semaphore that prevents libhoney from generating an event if set.

Methods in `Transmission`(s) that call `Cleaner#clean_data()` have been wrapped to set that semaphore to prevent any actions taken in the act of transmitting events from generating new events. `clean_data()` calls `to_s` for field values that are not simple types. In the particular case described below, value objects on event fields had `to_s` methods whose behavior would trigger instrumentation generating another event with similar value objects on fields. This causes a perpetual, high-volume stream of extraneous events. 

## Deep Details on the Problem

We ran into an infinite loop scenario that causes Honeycomb to send endless events. 🔁

In this particular case, using the Beeline + Rails + [Kaminari](https://github.com/kaminari/kaminari):

1. Rails 7.1 started including the `:locals` in the `render_partial.action_view` notifications: https://github.com/rails/rails/pull/45977
2. `Libhoney::Cleaner` ultimately winds up calling `#to_s` on the values in the `locals` hash.
3. The `Kaminari::Helpers::Paginator#to_s` method defers to `Kaminari::Helpers::Tag#to_s`, passing a reference to itself in the locals: https://github.com/kaminari/kaminari/blob/9182d065c144afa45c6b7cf444f810bea1fd7201/kaminari-core/lib/kaminari/helpers/paginator.rb#L77
4. The `Kaminari::Helpers::Tag#to_s` method renders a partial, triggering another `render_partial.action_view` span: https://github.com/kaminari/kaminari/blob/9182d065c144afa45c6b7cf444f810bea1fd7201/kaminari-core/lib/kaminari/helpers/tags.rb#L42
5. This new span now has the _same_ `Paginator` in its locals, which `Libhoney::Cleaner` will call `#to_s` on, which will trigger another `render_partial.action_view` span, forming the loop.

When using the `Libhoney::LogClient`, this infinite loop will result in a `SystemStackError` since `clean_data` is called synchronously from `Libhoney::LogTransmissionClient#add`. But it gets particularly pernicious when using the standard `Libhoney::Client`, where events are placed on a queue that background threads work off of. A new event is generated from inside the `send_loop` (when we call `clean_data`), but that doesn't blow up the stack because the event is just placed on the background queue; the cycle continues when some `send_loop` thread pulls the event off the queue, triggering yet another asynchronous event. It just keeps going on & on, spamming Honeycomb repeatedly without eating into the call stack!

## Short description of the changes

The idea in this PR is to prevent such infinite loops by making libhoney drop _any_ event generated from within the "workhorse" of the transmission. The implementation isn't too fancy: set a thread-local variable to keep track of when libhoney is transmitting an event, then check for that from `Libhoney::Event#send_presampled`.

I figured that this bug was hard enough to describe that a PR would help it make the most sense. The majority of the code is dedicated to unit tests that trigger the bug sans the particular Kaminari + Rails setup. But of course there might be some specifics to discuss with the solution implemented here:

- Should this new check be gated by a configuration? It's not clear to me that anyone is, can, or should be relying on events generated during transmission, but there might be concerns about backwards compatibility.
- Is it enough to just send a dropped response? Or should the original event be preserved somehow, in case someone wants to recover & send the event anyway? I reasoned that it was reasonable enough to follow the pattern established for sampling, but have no strong opinions.
- Any problems I've overlooked with using thread locals for this purpose? Funny enough, this is similar to the way Kaminari prevents spamming Active Support notifications: https://github.com/kaminari/kaminari/blob/9182d065c144afa45c6b7cf444f810bea1fd7201/kaminari-core/lib/kaminari/helpers/paginator.rb#L76-L79 + https://github.com/kaminari/kaminari/blob/9182d065c144afa45c6b7cf444f810bea1fd7201/kaminari-actionview/lib/kaminari/actionview/action_view_extension.rb#L14