### PR TITLE
fix: resolve test failures caused by new Sinatra behavior

### DIFF
--- a/test/stub_honeycomb_server.rb
+++ b/test/stub_honeycomb_server.rb
@@ -3,6 +3,7 @@ require 'sinatra/json'
 
 class StubHoneycombServer < Sinatra::Base
   set :json_encoder, :to_json
+  set :host_authorization, { permitted_hosts: [] }
 
   before do
     @batch = JSON.parse(request.body.read.to_s)


### PR DESCRIPTION
## Which problem is this PR solving?

- [Sinatra 4.1.0 introduced a host authorization option to Sinatra apps](https://github.com/sinatra/sinatra/pull/2053). That authorization check was failing requests made in tests.

## Short description of the changes

-  Update the Honeycomb test server stub to allow anybody to talk to it.

